### PR TITLE
Support multiple key/value pairs in single request to set route variants

### DIFF
--- a/apps/admin-web/src/app/components/RouteItem.tsx
+++ b/apps/admin-web/src/app/components/RouteItem.tsx
@@ -100,12 +100,12 @@ const RouteItem = ({ route }: Props) => {
             <Button
               onClick={() => {
                 // TODO investigate why this works with ../
-                fetch(`../_admin/api/route/${encodeURIComponent(route.id)}`, {
+                fetch(`../_admin/api/routeVariants/set`, {
                   method: 'POST',
                   headers: {
                     'Content-Type': 'application/json',
                   },
-                  body: JSON.stringify({ variant: variant.id }),
+                  body: JSON.stringify({ [route.id]: variant.id }),
                 });
               }}
             >

--- a/libs/core/src/lib/__tests__/admin-endpoints.spec.ts
+++ b/libs/core/src/lib/__tests__/admin-endpoints.spec.ts
@@ -49,10 +49,7 @@ describe('admin-endpoints', () => {
 
   describe('/_admin/routes', () => {
     it('should return all routes for admin GUI', async () => {
-      await mezzo.setMockVariant({
-        routeId: routeId,
-        variantId: variant1,
-      });
+      await mezzo.setMockVariant({ [routeId]: variant1 });
 
       const res = await request.get('/_admin/routes');
       expect(res.status).toBe(200);

--- a/libs/core/src/lib/__tests__/core-utils.spec.ts
+++ b/libs/core/src/lib/__tests__/core-utils.spec.ts
@@ -112,7 +112,7 @@ describe('core-utils', () => {
       const res = await request.get(route1Path);
       expect(res.body).toEqual({ someKey: a1Default });
 
-      await mezzo.setMockVariant({ routeId: route1, variantId: variant1 });
+      await mezzo.setMockVariant({ [route1]: variant1 });
       const res2 = await request.get(route1Path);
       expect(res2.body).toEqual({ someKey: variant1 });
     });

--- a/libs/core/src/lib/__tests__/route-file-io.spec.ts
+++ b/libs/core/src/lib/__tests__/route-file-io.spec.ts
@@ -98,10 +98,7 @@ describe('route-file-io', () => {
             return mezzo.util.respondWithFile(route, req, res);
           },
         });
-      await mezzo.setMockVariant({
-        routeId: routeId4Html,
-        variantId: variant1,
-      });
+      await mezzo.setMockVariant({ [routeId4Html]: variant1 });
       const res = await request.get(routePath4Html);
       expect(res.status).toBe(200);
       expect(res.text).toEqual(variantHtml);
@@ -186,10 +183,7 @@ describe('route-file-io', () => {
       expect(res.status).toBe(200);
       expect(res.body).toEqual({ variant: _default });
 
-      await mezzo.setMockVariant({
-        routeId: routeId2,
-        variantId: variant1,
-      });
+      await mezzo.setMockVariant({ [routeId2]: variant1 });
 
       const res2 = await request.get(routePath2);
       expect(res2.body).toEqual({ variant: variant1 });
@@ -227,10 +221,7 @@ describe('route-file-io', () => {
       const res = await request.get('/part1/someDynamicPart2Path');
       expect(res.status).toBe(200);
       expect(res.body).toEqual({ variant: _default });
-      await mezzo.setMockVariant({
-        routeId: routeId3Dynamic,
-        variantId: variant1,
-      });
+      await mezzo.setMockVariant({ [routeId3Dynamic]: variant1 });
       const res2 = await request.get('/part1/someDynamicPart2Path');
       expect(res2.body).toEqual({ variant: 'other' });
       const res3 = await request.get('/part1/someDynamicPart2PathAlt');

--- a/libs/core/src/lib/__tests__/route-state.spec.ts
+++ b/libs/core/src/lib/__tests__/route-state.spec.ts
@@ -77,7 +77,7 @@ describe('route-state', () => {
       await mezzo.setMockVariantForSession(sessionId, {
         [routeId]: variant2,
       });
-      await mezzo.setMockVariant({ routeId, variantId: variant2 });
+      await mezzo.setMockVariant({ [routeId]: variant2 });
       const res1 = await request
         .get(routePath)
         .set(X_REQUEST_SESSION, sessionId)
@@ -128,7 +128,7 @@ describe('route-state', () => {
       await mezzo.setMockVariantForSession(sessionId, {
         [routeId]: variant1,
       });
-      await mezzo.setMockVariant({ routeId, variantId: variant2 });
+      await mezzo.setMockVariant({ [routeId]: variant2 });
       const res1 = await request
         .get(routePath)
         .set(X_REQUEST_SESSION, sessionId);

--- a/libs/core/src/lib/admin.ts
+++ b/libs/core/src/lib/admin.ts
@@ -11,20 +11,24 @@ export const addAdminEndpoints = (app: express.Express, mezzo: Mezzo) => {
     res.json(mezzo.serialiazeRoutes());
   });
 
-  // setMockVariahttps://github.com/sgoff0/midway/blob/6614a6a91d3060951e99326c68333ebf78563e8c/src/utils/common-utils.ts#L318-L356nt
-  app.post(`${MEZZO_API_PATH}/route/:id`, (req, res) => {
-    const routeId = req.params.id;
-    const variantId = req.body.variant;
-    const index = findRouteIndexById(routeId, mezzo.userRoutes);
-    const foundRoute = mezzo.userRoutes[index];
-    if (foundRoute) {
-      const updatedItem = foundRoute.setVariant(variantId);
-      mezzo.userRoutes[index] = updatedItem;
-    } else {
-      logger.warn(
-        `Could not find route for ${routeId} to set variant ${variantId}`
-      );
-    }
+  app.post(`${MEZZO_API_PATH}/routeVariants/set`, (req, res) => {
+    const payload: RouteVariants = req.body;
+
+    Object.keys(payload).forEach((routeId) => {
+      const variantId = payload[routeId];
+
+      const index = findRouteIndexById(routeId, mezzo.userRoutes);
+      const foundRoute = mezzo.userRoutes[index];
+      if (foundRoute) {
+        const updatedItem = foundRoute.setVariant(variantId);
+        mezzo.userRoutes[index] = updatedItem;
+      } else {
+        logger.warn(
+          `Could not find route for ${routeId} to set variant ${variantId}`
+        );
+      }
+    });
+
     res.sendStatus(200);
   });
 

--- a/libs/core/src/lib/core.ts
+++ b/libs/core/src/lib/core.ts
@@ -5,7 +5,6 @@ import axios from 'axios';
 import { CommonUtils } from '../utils/common-utils';
 import {
   MiddlewareFn,
-  MockVariantOptions,
   RouteData,
   RouteVariants,
   ServerOptions,
@@ -117,14 +116,9 @@ export class Mezzo {
   };
 
   // https://github.com/sgoff0/midway/blob/6614a6a91d3060951e99326c68333ebf78563e8c/src/utils/common-utils.ts#L318-L356
-  public setMockVariant = async (options: MockVariantOptions) => {
-    const url = `http://localhost:${
-      this.port
-    }${MEZZO_API_PATH}/route/${encodeURIComponent(options.routeId)}`;
-
-    await axios.post(url, {
-      variant: options.variantId,
-    });
+  public setMockVariant = async (payload: RouteVariants) => {
+    const url = `http://localhost:${this.port}${MEZZO_API_PATH}/routeVariants/set`;
+    await axios.post(url, payload);
   };
 
   public setMockVariantForSession = async (

--- a/libs/core/src/types.ts
+++ b/libs/core/src/types.ts
@@ -81,13 +81,5 @@ export interface FileHandlerOptions {
   transpose?: any;
 }
 
-export interface MockVariantOptions {
-  mockPort?: number;
-  // fixture: string,
-  routeId: string;
-  variantId: string;
-  mezzoSessionId?: string;
-}
-
 // export type SessionPayload = Record<string, RouteVariants>; // Session to RotueVariants mapping
 export type RouteVariants = Record<string, string>; // route id to variant id mapping


### PR DESCRIPTION
This paves the way for profiles as in one single API call the client can set any amount of variants desired. 

Client can then persist desired key/value permutations, and when profile is selected make 1 API call to condition mezzo appropriately. 

Prior to this `setMockVariant` would have to be called N times for N variants. 