### PR TITLE
Re-implement one click payload request

### DIFF
--- a/apps/admin-web/src/app/components/RouteItem.tsx
+++ b/apps/admin-web/src/app/components/RouteItem.tsx
@@ -114,37 +114,35 @@ const RouteItem = ({ route, selectedItem, setSelectedItem }: Props) => {
         {route?.titleIcons?.map((icon) => (
           <GetLinkableIcon {...icon} />
         ))}
-        {selectedItem === route.id && (
-          <Button
-            variant="contained"
-            size="small"
-            sx={{
-              mr: 2,
-              backgroundColor: getColors().textColor,
-              maxHeight: 30,
-              alignSelf: 'center',
-            }}
-            onClick={() => {
-              if (route.method?.toUpperCase() === 'GET') {
-                openInNewTab(route.path.toString());
-              } else {
-                // If not a POST, currently assumes response is always JSON, fetch via API then open
-                fetch(route.path.toString(), {
-                  method: route.method,
-                  headers: {
-                    Accept: 'application/json',
-                    'Content-Type': 'application/json',
-                  },
-                  body: route.method === 'GET' ? undefined : '{}',
-                })
-                  .then((r) => r.json())
-                  .then(openJsonInNewTab);
-              }
-            }}
-          >
-            <OpenInNew />
-          </Button>
-        )}
+        <Button
+          variant="contained"
+          size="small"
+          sx={{
+            mr: 2,
+            backgroundColor: getColors().textColor,
+            maxHeight: 30,
+            alignSelf: 'center',
+          }}
+          onClick={() => {
+            if (route.method?.toUpperCase() === 'GET') {
+              openInNewTab(route.path.toString());
+            } else {
+              // If not a POST, currently assumes response is always JSON, fetch via API then open
+              fetch(route.path.toString(), {
+                method: route.method,
+                headers: {
+                  Accept: 'application/json',
+                  'Content-Type': 'application/json',
+                },
+                body: route.method === 'GET' ? undefined : '{}',
+              })
+                .then((r) => r.json())
+                .then(openJsonInNewTab);
+            }
+          }}
+        >
+          <OpenInNew />
+        </Button>
         <Container
           sx={{
             backgroundColor: getColors().textColor,


### PR DESCRIPTION
Recent change, grrr so many clicks if I want to preview the JSON payload, why suppress the button?
![OneClickLinks](https://user-images.githubusercontent.com/3091143/164873764-21ce7378-08ce-4741-9a7b-a4f410c2f1b4.gif)

Now active variant payload is just 1 click away 
![image](https://user-images.githubusercontent.com/3091143/164873725-c9cf7974-8d67-4e57-b9a3-b66e022dbf12.png)
