### PR TITLE
Simplify build steps and publish to npm when a release is created.

### DIFF
--- a/.github/workflows/npmPublish.yml
+++ b/.github/workflows/npmPublish.yml
@@ -1,0 +1,20 @@
+name: Publish core to npmjs
+on:
+  release:
+    types: [created]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+      - run: npm run test
+      - run: npm run build:core:prod
+      - run: npm publish dist/libs/core --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -4,10 +4,6 @@
 
 - Install all dependencies
   - `npm i`
-- Make sure you have nx installed globally
-  - `npm i -g nx`
-- Build interfaces
-  - `nx build interfaces`
 - Run dev project
   - `npm run dev`
 
@@ -19,24 +15,16 @@ This project was generated using [Nx](https://nx.dev).
 
 # Building
 
-- `npm run build`
-  - Builds admin web and core projects
-- `nx prepare core`
-  - Injects admin web output into core.
-  - While not wired up at some point this way mezzo can serve the site while also serving the mock API
-  - Be sure any changes are built before you run `npm build:executor` aka `npx tsc tools/executors/buildCoreWithWeb/impl`
+The only non-intuitive piece during building vs development is in development the admin website and core APIs exist on two separate ports by 2 separate projects.
+When building to publish to npm the web project is actually injected into the core project so that it is served by the same express server powering the core module.
+This is done under the hood by the `nx prepare core` step powered bythe buildCoreWithWeb/impl file.
+If changes are made to that file compile it `npx tsc tools/executors/buildCoreWithWeb/impl` via `npm build:executor`
 
 # Publishing
 
-Run `npm publish dist/libs/core --access public` from the root of the project
+Run `npm publish dist/libs/core --access public` from the root of the project.
 
-# Other Commands
+# Test
 
-- Run dev api and web
-  - `npm run dev`
-- Run tests for api
-  - `nx test core`
-- Serve only api
-  - `nx serve core`
-- Build the projects
-  - `npm run build`
+- Run tests
+  - `npm test`

--- a/libs/core/package.json
+++ b/libs/core/package.json
@@ -1,4 +1,8 @@
 {
   "name": "@caribou-crew/mezzo-core",
-  "version": "0.1.0"
+  "version": "0.2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/caribou-crew/mezzo.git"
+  }
 }

--- a/libs/core/src/lib/__tests__/redirect.spec.ts
+++ b/libs/core/src/lib/__tests__/redirect.spec.ts
@@ -5,7 +5,7 @@ describe('redirects', () => {
   let request: SuperTestRequest.SuperTest<SuperTestRequest.Test>;
 
   beforeEach(async () => {
-    const port = 3002;
+    const port = 3003;
     request = SuperTestRequest(`http://localhost:${port}`);
     await mezzo.start({
       port,

--- a/package.json
+++ b/package.json
@@ -2,11 +2,18 @@
   "name": "mezzo",
   "version": "0.0.0",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/caribou-crew/mezzo.git"
+  },
   "scripts": {
     "start": "nx serve",
-    "dev": "cross-env NODE_ENV=development nx run-many --target=serve --projects=core,admin-web",
-    "build": "cross-env NODE_ENV=production nx run-many --target=build --projects=core,admin-web",
+    "dev:serve": "nx run-many --target=serve --projects=core,admin-web",
+    "dev": "cross-env NODE_ENV=development npm run build:shared-libs && npm run dev:serve",
+    "build": "cross-env NODE_ENV=production nx run-many --all --target=build",
     "build:executor": "npx tsc tools/executors/buildCoreWithWeb/impl",
+    "build:shared-libs": "nx run-many --target=build --projects=constants,interfaces",
+    "build:core:prod": "cross-env NODE_ENV=production npm run build:shared-libs && nx prepare core",
     "test": "nx run-many --all --target=test --parallel",
     "clean": "rm -rf node_modules/ && npm install",
     "lintAll": "nx run-many --all --target=lint --parallel",


### PR DESCRIPTION
Closes #50, although I can't fully test until this is in the main branch and I cut a release.