### PR TITLE
Support github dynamic icon

### DIFF
--- a/apps/admin-web/src/app/components/DynamicIcon.tsx
+++ b/apps/admin-web/src/app/components/DynamicIcon.tsx
@@ -1,4 +1,5 @@
 import { Icon } from '@mui/material';
+import GitHubIcon from '@mui/icons-material/GitHub';
 
 type Props = {
   name: string;
@@ -14,6 +15,11 @@ type Props = {
  * @returns
  */
 export default function DynamicIcon(props: Props) {
-  const item = <Icon style={props.style}>{props.name}</Icon>;
+  let item;
+  if (props.name.toLowerCase() === 'github') {
+    item = <GitHubIcon style={props.style} />;
+  } else {
+    item = <Icon style={props.style}>{props.name}</Icon>;
+  }
   return item;
 }

--- a/libs/core/src/index.ts
+++ b/libs/core/src/index.ts
@@ -88,6 +88,12 @@ if (arg === 'start') {
           id: 'POST /api/food/drink',
           path: '/api/food/drink',
           method: 'POST',
+          titleIcons: [
+            {
+              name: 'GitHub',
+              link: 'https://github.com/caribou-crew/mezzo',
+            },
+          ],
           handler: function (req, res) {
             res.json({ someKey: 'C', someOtherKey: 'D', yetAnotherKey: 'E' });
           },


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3091143/165422402-0a180fe9-4537-4333-8015-edc3573c0aa2.png)

This is a one-off as it doesn't render anything unless <GitHubIcon /> is used, but GitHub icons are common enough in this use case to warrant it for now.

Closes #68 