### PR TITLE
Allow for variant categorization

### DIFF
--- a/apps/admin-web/src/app/app.tsx
+++ b/apps/admin-web/src/app/app.tsx
@@ -1,5 +1,8 @@
 import React, { useEffect, useState } from 'react';
-import { GetMezzoRoutesRouteData } from '@caribou-crew/mezzo-interfaces';
+import {
+  GetMezzoRoutesRouteData,
+  VariantCategory,
+} from '@caribou-crew/mezzo-interfaces';
 import { Flipper, Flipped } from 'react-flip-toolkit';
 
 import {
@@ -20,6 +23,9 @@ type SortProperty = 'method' | 'path';
 export const App = () => {
   const [routes, setRoutes] = useState<GetMezzoRoutesRouteData[]>([]);
   const [version, setVersion] = useState<string>('');
+  const [variantCategories, setVariantCategories] = useState<VariantCategory[]>(
+    []
+  );
   const [displayedRoutes, setDisplayedRoutes] = useState<
     GetMezzoRoutesRouteData[]
   >([]);
@@ -33,6 +39,12 @@ export const App = () => {
       const data = await response.json();
       setRoutes(data.routes);
       setVersion(data.appVersion);
+      setVariantCategories(
+        (data.variantCategories || []).sort(
+          (a: VariantCategory, b: VariantCategory) =>
+            (a?.order ?? 0) - (b?.order ?? 0)
+        )
+      );
       setDisplayedRoutes(data.routes);
     };
 
@@ -45,6 +57,7 @@ export const App = () => {
         <div>
           <RouteItem
             route={route}
+            variantCategories={variantCategories}
             key={route.id}
             selectedItem={selectedItem}
             setSelectedItem={(id) => setSelectedItem(id)}

--- a/apps/admin-web/src/app/components/RouteCategory.tsx
+++ b/apps/admin-web/src/app/components/RouteCategory.tsx
@@ -1,0 +1,53 @@
+import { Container, Typography } from '@mui/material';
+
+import {
+  GetMezzoRoutesRouteData,
+  VariantCategory,
+} from '@caribou-crew/mezzo-interfaces';
+import VariantButton from './VariantButton';
+
+type Props = {
+  category: VariantCategory;
+  route: GetMezzoRoutesRouteData;
+  activeVariant: string;
+  setActiveVariant: (arg0: string) => void;
+};
+
+const RouteCategory = ({
+  route,
+  category,
+  activeVariant,
+  setActiveVariant,
+}: Props) => {
+  const variants = route.variants.filter((v) => v.category === category?.name);
+  if (variants.length === 0) {
+    return null;
+  }
+  return (
+    <>
+      <Typography variant="subtitle2" sx={{ pt: 2 }}>
+        {category?.name ?? 'Variants'}
+      </Typography>
+      <Container
+        disableGutters
+        sx={{
+          ml: 8,
+        }}
+      >
+        {route.variants
+          .filter((v) => v.category === category?.name)
+          .map((variant, idx) => (
+            <VariantButton
+              key={`${route.id}:${variant.id}`}
+              activeVariant={activeVariant}
+              setActiveVariant={setActiveVariant}
+              route={route}
+              variant={variant}
+            />
+          ))}
+      </Container>
+    </>
+  );
+};
+
+export default RouteCategory;

--- a/apps/admin-web/src/app/components/RouteItem.tsx
+++ b/apps/admin-web/src/app/components/RouteItem.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import {
   Container,
   Button,
@@ -13,34 +13,26 @@ import { OpenInNew } from '@mui/icons-material';
 import { openInNewTab, openJsonInNewTab } from '../utils/urlHelper';
 import {
   GetMezzoRoutesRouteData,
-  GetMezzoRoutesVariantData,
   RouteOrVariantIcon,
+  VariantCategory,
 } from '@caribou-crew/mezzo-interfaces';
 import DynamicIcon from './DynamicIcon';
-import VariantButton from './VariantButton';
+import RouteCategory from './RouteCategory';
 
 type Props = {
   route: GetMezzoRoutesRouteData;
   selectedItem: string;
   setSelectedItem: (id: string) => void;
+  variantCategories: VariantCategory[];
 };
 
-function getCategoryNames(variants: GetMezzoRoutesVariantData[]) {
-  console.log('Calc cat names');
-  return [
-    ...new Set(variants.map((v) => v.category)),
-    { name: undefined, order: 0 },
-  ]
-    .filter((i) => i != null)
-    .sort((a, b) => (a?.order ?? 0) - (b?.order ?? 0));
-}
-
-const RouteItem = ({ route, selectedItem, setSelectedItem }: Props) => {
+const RouteItem = ({
+  route,
+  selectedItem,
+  setSelectedItem,
+  variantCategories,
+}: Props) => {
   const [activeVariant, setActiveVariant] = useState('default');
-  const categoryNames = useMemo(
-    () => getCategoryNames(route.variants),
-    [route.variants]
-  );
 
   const getColors = () => {
     let backgroundColor;
@@ -217,30 +209,13 @@ const RouteItem = ({ route, selectedItem, setSelectedItem }: Props) => {
               Active Variant Id:{' '}
               {<span style={{ color: 'green' }}>{activeVariant}</span>}
             </Typography>
-            {categoryNames.map((category) => (
-              <>
-                <Typography variant="subtitle2" sx={{ pt: 2 }}>
-                  {category?.name ?? 'Variants'}
-                </Typography>
-                <Container
-                  disableGutters
-                  sx={{
-                    ml: 8,
-                  }}
-                >
-                  {route.variants
-                    .filter((v) => v.category?.name === category?.name)
-                    .map((variant, idx) => (
-                      <VariantButton
-                        key={`${route.id}:${variant.id}`}
-                        activeVariant={activeVariant}
-                        setActiveVariant={setActiveVariant}
-                        route={route}
-                        variant={variant}
-                      />
-                    ))}
-                </Container>
-              </>
+            {variantCategories.map((category) => (
+              <RouteCategory
+                category={category}
+                route={route}
+                activeVariant={activeVariant}
+                setActiveVariant={setActiveVariant}
+              />
             ))}
           </Container>
         </Box>

--- a/apps/admin-web/src/app/components/RouteItem.tsx
+++ b/apps/admin-web/src/app/components/RouteItem.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import {
   Container,
   Button,
@@ -13,6 +13,7 @@ import { OpenInNew } from '@mui/icons-material';
 import { openInNewTab, openJsonInNewTab } from '../utils/urlHelper';
 import {
   GetMezzoRoutesRouteData,
+  GetMezzoRoutesVariantData,
   RouteOrVariantIcon,
 } from '@caribou-crew/mezzo-interfaces';
 import DynamicIcon from './DynamicIcon';
@@ -24,8 +25,22 @@ type Props = {
   setSelectedItem: (id: string) => void;
 };
 
+function getCategoryNames(variants: GetMezzoRoutesVariantData[]) {
+  console.log('Calc cat names');
+  return [
+    ...new Set(variants.map((v) => v.category)),
+    { name: undefined, order: 0 },
+  ]
+    .filter((i) => i != null)
+    .sort((a, b) => (a?.order ?? 0) - (b?.order ?? 0));
+}
+
 const RouteItem = ({ route, selectedItem, setSelectedItem }: Props) => {
   const [activeVariant, setActiveVariant] = useState('default');
+  const categoryNames = useMemo(
+    () => getCategoryNames(route.variants),
+    [route.variants]
+  );
 
   const getColors = () => {
     let backgroundColor;
@@ -189,7 +204,7 @@ const RouteItem = ({ route, selectedItem, setSelectedItem }: Props) => {
         <Box>
           <Divider></Divider>
           <Container
-            sx={{ pt: 2 }}
+            sx={{ pt: 2, pb: 2 }}
             onClick={(event) => {
               event.stopPropagation();
             }}
@@ -202,27 +217,31 @@ const RouteItem = ({ route, selectedItem, setSelectedItem }: Props) => {
               Active Variant Id:{' '}
               {<span style={{ color: 'green' }}>{activeVariant}</span>}
             </Typography>
-            <Typography variant="subtitle2" sx={{ pt: 2 }}>
-              Variants
-            </Typography>
-            <Container
-              disableGutters
-              sx={{
-                pb: 2,
-                mt: 2,
-                ml: 8,
-              }}
-            >
-              {route.variants.map((variant, index) => (
-                <VariantButton
-                  key={`${route.id}:${variant.id}`}
-                  activeVariant={activeVariant}
-                  setActiveVariant={setActiveVariant}
-                  route={route}
-                  variant={variant}
-                />
-              ))}
-            </Container>
+            {categoryNames.map((category) => (
+              <>
+                <Typography variant="subtitle2" sx={{ pt: 2 }}>
+                  {category?.name ?? 'Variants'}
+                </Typography>
+                <Container
+                  disableGutters
+                  sx={{
+                    ml: 8,
+                  }}
+                >
+                  {route.variants
+                    .filter((v) => v.category?.name === category?.name)
+                    .map((variant, idx) => (
+                      <VariantButton
+                        key={`${route.id}:${variant.id}`}
+                        activeVariant={activeVariant}
+                        setActiveVariant={setActiveVariant}
+                        route={route}
+                        variant={variant}
+                      />
+                    ))}
+                </Container>
+              </>
+            ))}
           </Container>
         </Box>
       )}

--- a/libs/constants/package.json
+++ b/libs/constants/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@caribou-crew/mezzo-constants",
-  "version": "0.1.0"
+  "version": "0.2.0"
 }

--- a/libs/constants/src/lib/constants.ts
+++ b/libs/constants/src/lib/constants.ts
@@ -4,3 +4,5 @@ export const DEFAULT_VARIANT = 'default';
 export const MEZZO_API_PATH = '/_admin/api';
 export const LOCAL_HOST = 'localhost';
 export const DEFAULT_PORT = 8000;
+export const DEFAULT_VARIANT_CATEGORY = 'Variants';
+export const GLOBAL_VARIANT_CATEGORY = 'Global Variants';

--- a/libs/core/src/index.ts
+++ b/libs/core/src/index.ts
@@ -46,6 +46,10 @@ if (arg === 'start') {
           handler: function (req, res) {
             res.json({ someKey: 'C' });
           },
+          category: {
+            name: 'Approved Test Variant',
+            order: -1,
+          },
         })
         .variant({
           id: 'variant3',
@@ -211,6 +215,10 @@ if (arg === 'start') {
       mezzo.addGlobalVariant({
         id: '500',
         label: '500 error',
+        category: {
+          name: 'Global Variants',
+          order: 100,
+        },
         callback: function (req, res) {
           res.sendStatus(500);
         },

--- a/libs/core/src/index.ts
+++ b/libs/core/src/index.ts
@@ -2,8 +2,11 @@ import mezzo from './lib/core';
 export default mezzo;
 import * as path from 'path';
 import { resourcesPath } from './utils/pathHelpers';
+import { GLOBAL_VARIANT_CATEGORY } from '@caribou-crew/mezzo-constants';
 
 const [arg] = process.argv.slice(2);
+
+const customCategory = 'Approved Test Variant';
 
 if (arg === 'start') {
   const mockedDirectory = path.join(resourcesPath, 'mocked-data');
@@ -12,6 +15,12 @@ if (arg === 'start') {
       port: 8000,
       mockedDirectory,
       adminEndpoint: 'mezzo',
+      variantCategories: [
+        {
+          name: customCategory,
+          order: -1,
+        },
+      ],
     });
 
     if (process.env.USE_DUMMY_DATA === 'true') {
@@ -46,10 +55,7 @@ if (arg === 'start') {
           handler: function (req, res) {
             res.json({ someKey: 'C' });
           },
-          category: {
-            name: 'Approved Test Variant',
-            order: -1,
-          },
+          category: customCategory,
         })
         .variant({
           id: 'variant3',
@@ -215,10 +221,7 @@ if (arg === 'start') {
       mezzo.addGlobalVariant({
         id: '500',
         label: '500 error',
-        category: {
-          name: 'Global Variants',
-          order: 100,
-        },
+        category: GLOBAL_VARIANT_CATEGORY,
         callback: function (req, res) {
           res.sendStatus(500);
         },

--- a/libs/core/src/lib/__tests__/admin-endpoints.spec.ts
+++ b/libs/core/src/lib/__tests__/admin-endpoints.spec.ts
@@ -1,4 +1,7 @@
-import { MEZZO_API_PATH } from '@caribou-crew/mezzo-constants';
+import {
+  DEFAULT_VARIANT_CATEGORY,
+  MEZZO_API_PATH,
+} from '@caribou-crew/mezzo-constants';
 import * as SuperTestRequest from 'supertest';
 import mezzo from '../core';
 
@@ -62,9 +65,11 @@ describe('admin-endpoints', () => {
           path: routePath,
           variants: [
             {
+              category: DEFAULT_VARIANT_CATEGORY,
               id: _default,
             },
             {
+              category: DEFAULT_VARIANT_CATEGORY,
               id: variant1,
               label: `${variant1}-label`,
             },
@@ -77,6 +82,7 @@ describe('admin-endpoints', () => {
           path: 'route2',
           variants: [
             {
+              category: DEFAULT_VARIANT_CATEGORY,
               id: _default,
             },
           ],

--- a/libs/core/src/lib/admin.ts
+++ b/libs/core/src/lib/admin.ts
@@ -12,6 +12,7 @@ export const addAdminEndpoints = (app: express.Express, mezzo: Mezzo) => {
     res.json({
       routes: mezzo.serialiazeRoutes(),
       appVersion: version,
+      variantCategories: mezzo.variantCategories,
     });
   });
 

--- a/libs/core/src/lib/core.ts
+++ b/libs/core/src/lib/core.ts
@@ -217,6 +217,7 @@ export class Mezzo {
           id: key,
           label: variant.label,
           icons: variant.icons,
+          category: variant?.category,
         });
       });
 

--- a/libs/core/src/lib/core.ts
+++ b/libs/core/src/lib/core.ts
@@ -20,11 +20,12 @@ import {
   DEFAULT_PORT,
   MEZZO_API_PATH,
   LOCAL_HOST,
+  DEFAULT_VARIANT_CATEGORY,
+  GLOBAL_VARIANT_CATEGORY,
 } from '@caribou-crew/mezzo-constants';
 
 import * as bodyParser from 'body-parser';
 import {
-  GetMezzoRoutes,
   GetMezzoRoutesRouteData,
   GetMezzoRoutesVariantData,
 } from '@caribou-crew/mezzo-interfaces';
@@ -45,6 +46,7 @@ export class Mezzo {
   public mockedDirectory;
   public port;
   public redirect;
+  public variantCategories;
 
   private _resetRouteState = () => {
     this.userRoutes.length = 0;
@@ -81,6 +83,17 @@ export class Mezzo {
     this.util = new CommonUtils(this.userRoutes, this.fs, this.mockedDirectory);
     this.sessionState = new SessionState();
     this.port = options?.port ?? DEFAULT_PORT;
+    this.variantCategories = [
+      {
+        name: DEFAULT_VARIANT_CATEGORY,
+        order: 0,
+      },
+      {
+        name: GLOBAL_VARIANT_CATEGORY,
+        order: 100,
+      },
+      ...(options?.variantCategories || []),
+    ];
 
     return new Promise((resolve) => {
       this.server = createServer(this.app).listen(this.port, () => {
@@ -209,6 +222,7 @@ export class Mezzo {
       variantRetVal.push({
         id: 'default',
         icons: route.icons,
+        category: route.category,
       });
 
       // add route specific variants

--- a/libs/core/src/models/route-model.ts
+++ b/libs/core/src/models/route-model.ts
@@ -3,6 +3,7 @@ import { Request, RequestHandler } from 'express';
 import { CallbackType, HandlerType, RouteData, VariantData } from '../types';
 import {
   DEFAULT_VARIANT,
+  DEFAULT_VARIANT_CATEGORY,
   X_REQUEST_SESSION,
   X_REQUEST_VARIANT,
 } from '@caribou-crew/mezzo-constants';
@@ -48,8 +49,10 @@ export class Route {
   public path: string | RegExp;
   public icons: RouteOrVariantIcon[];
   public titleIcons: RouteOrVariantIcon[];
+  public category: string;
 
   constructor(routeData: RouteData, sessionState: SessionState) {
+    this.category = routeData.category ?? DEFAULT_VARIANT_CATEGORY;
     this.routeData = routeData;
     this.titleIcons = routeData.titleIcons;
     this.icons = routeData.icons;
@@ -116,6 +119,9 @@ export class Route {
    * @returns
    */
   public variant = (variantData: VariantData) => {
+    if (variantData.category == null) {
+      variantData.category = DEFAULT_VARIANT_CATEGORY;
+    }
     this._variants.set(variantData.id, variantData);
     logger.info(
       `Adding to variants, size of ${this.path} is now ${this._variants.size}`

--- a/libs/core/src/types.ts
+++ b/libs/core/src/types.ts
@@ -44,6 +44,10 @@ export interface RouteAndVariantData {
   handler?: HandlerType;
   titleIcons?: RouteOrVariantIcon[];
   icons?: RouteOrVariantIcon[];
+  category?: {
+    name: string;
+    order: number;
+  };
 }
 
 export type HandlerType = RequestHandler;

--- a/libs/core/src/types.ts
+++ b/libs/core/src/types.ts
@@ -1,4 +1,7 @@
-import { RouteOrVariantIcon } from '@caribou-crew/mezzo-interfaces';
+import {
+  RouteOrVariantIcon,
+  VariantCategory,
+} from '@caribou-crew/mezzo-interfaces';
 import { Request, Response, NextFunction, RequestHandler } from 'express';
 import { Route } from './models/route-model';
 
@@ -19,6 +22,7 @@ export interface ServerOptions {
   adminEndpoint?: string;
   mockedDirectory?: string;
   fsOverride?: any;
+  variantCategories?: VariantCategory[];
 }
 
 /**
@@ -44,10 +48,7 @@ export interface RouteAndVariantData {
   handler?: HandlerType;
   titleIcons?: RouteOrVariantIcon[];
   icons?: RouteOrVariantIcon[];
-  category?: {
-    name: string;
-    order: number;
-  };
+  category?: string;
 }
 
 export type HandlerType = RequestHandler;

--- a/libs/interfaces/package.json
+++ b/libs/interfaces/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@caribou-crew/mezzo-interfaces",
-  "version": "0.1.0"
+  "version": "0.2.0"
 }

--- a/libs/interfaces/src/lib/interfaces.ts
+++ b/libs/interfaces/src/lib/interfaces.ts
@@ -17,6 +17,10 @@ export interface GetMezzoRoutesVariantData {
   id: string;
   label?: string;
   icons?: RouteOrVariantIcon[];
+  category?: {
+    name: string;
+    order: number;
+  };
 }
 
 // TODO, this is almost a duplicate of core/src/types RouteData, address? This is the html facing API return value though

--- a/libs/interfaces/src/lib/interfaces.ts
+++ b/libs/interfaces/src/lib/interfaces.ts
@@ -17,10 +17,7 @@ export interface GetMezzoRoutesVariantData {
   id: string;
   label?: string;
   icons?: RouteOrVariantIcon[];
-  category?: {
-    name: string;
-    order: number;
-  };
+  category?: string;
 }
 
 // TODO, this is almost a duplicate of core/src/types RouteData, address? This is the html facing API return value though
@@ -37,3 +34,8 @@ export interface GetMezzoRoutesRouteData {
   custom?: Record<any, any>;
   titleIcons?: RouteOrVariantIcon[];
 }
+
+export type VariantCategory = {
+  name: string;
+  order: number;
+};


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3091143/165429678-ca68735f-e2f7-4faf-99c6-7f567cc5baf2.png)

User can now create custom variant categories.

By default uncategorized variants fall under a "Variants" header with sort order 0.
By default global variants fall under a "Global Variants" header with sort order 100.
In this example one variant was tagged with "Approved Test Variant" with sort order -1.
UI renders in ascending order.


~~One thought is that categories and sort orders possibly should be created & configured globally as if there are two variants with the same category but different sort order, 1 it doesn't make sense and 2 the sort order respected will likely be the first one encountered.~~ Addressed in second commit

Closes #71