### PR TITLE
Fix Key error and clean styling

### DIFF
--- a/apps/admin-web/src/app/app.tsx
+++ b/apps/admin-web/src/app/app.tsx
@@ -3,11 +3,13 @@ import { Flipper, Flipped } from 'react-flip-toolkit';
 
 import {
   TextField,
-  Grid,
   Box,
   Container,
   Button,
   Typography,
+  CssBaseline,
+  Grid,
+  Divider,
 } from '@mui/material';
 import { ArrowDropDown, ArrowDropUp } from '@mui/icons-material';
 import RouteItem from './components/RouteItem';
@@ -71,18 +73,27 @@ export const App = () => {
   const _renderShowByContainer = () => {
     return (
       <Container
+        disableGutters
         sx={{
           display: 'flex',
           flexDirection: 'row',
           alignItems: 'flex-start',
           mt: 1.1,
           gap: 1,
+          '@media (max-width:475px)': {
+            flexDirection: 'column',
+            alignItems: 'center',
+            mt: 0,
+          },
         }}
       >
-        <Typography align="center" variant="h6">
-          Sort By:
-        </Typography>
+        <Box>
+          <Typography noWrap align="center" variant="h6">
+            Sort By:
+          </Typography>
+        </Box>
         <Button
+          fullWidth
           variant="outlined"
           onClick={() => setSort('method')}
           startIcon={getSortIcon('method')}
@@ -90,6 +101,7 @@ export const App = () => {
           Method
         </Button>
         <Button
+          fullWidth
           variant="outlined"
           onClick={() => setSort('path')}
           startIcon={getSortIcon('path')}
@@ -97,6 +109,7 @@ export const App = () => {
           Path
         </Button>
         <Button
+          fullWidth
           variant="outlined"
           color="error"
           onClick={() => setSort('')}
@@ -110,17 +123,15 @@ export const App = () => {
 
   const _renderSearchInput = () => {
     return (
-      <Container>
-        <TextField
-          fullWidth
-          id="outlined-search"
-          type="search"
-          label="Filter"
-          variant="outlined"
-          onChange={filter}
-          value={filterValue}
-        />
-      </Container>
+      <TextField
+        fullWidth
+        id="outlined-search"
+        type="search"
+        label="Filter"
+        variant="outlined"
+        onChange={filter}
+        value={filterValue}
+      />
     );
   };
 
@@ -137,49 +148,48 @@ export const App = () => {
   };
 
   return (
-    <Container component="main" maxWidth="lg">
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'row',
-          alignItems: 'center',
-          justifyContent: 'center',
-        }}
-      >
-        <Grid container spacing={2}>
-          <Grid item xs={12}>
-            <Header name="Mezzo"></Header>
-            <Box
-              sx={{
-                display: 'flex',
-                flexDirection: 'row',
-                justifyContent: 'space-between',
-              }}
-            >
-              {_renderShowByContainer()}
-              {_renderSearchInput()}
-            </Box>
+    <>
+      <CssBaseline />
+      <Header name="Mezzo"></Header>
+      <Container component="main" maxWidth="lg">
+        <Grid container spacing={1} sx={{ my: 2 }}>
+          <Grid item xs={12} sm={12} md={6}>
+            {_renderShowByContainer()}
           </Grid>
-          <Grid item xs={12}>
-            {displayedRoutes.length > 0 ? (
-              <Flipper
-                flipKey={displayedRoutes.reduce(
-                  (prev, current) => prev + current.id,
-                  ''
-                )}
-              >
-                {renderRouteList()}
-              </Flipper>
-            ) : (
-              _renderTypography()
-            )}
-            <Typography align="center" sx={{ mt: 5 }}>
-              {version ? `v${version}` : null}
-            </Typography>
+          <Grid item xs={12} sm={12} md={6}>
+            {_renderSearchInput()}
           </Grid>
         </Grid>
-      </Box>
-    </Container>
+        <Divider />
+        <Typography
+          variant="h6"
+          sx={{
+            mt: 3,
+            '@media (max-width:475px)': {
+              textAlign: 'center',
+            },
+          }}
+          gutterBottom
+        >
+          Routes
+        </Typography>
+        {displayedRoutes.length > 0 ? (
+          <Flipper
+            flipKey={displayedRoutes.reduce(
+              (prev, current) => prev + current.id,
+              ''
+            )}
+          >
+            {renderRouteList()}
+          </Flipper>
+        ) : (
+          _renderTypography()
+        )}
+        <Typography align="center" sx={{ mt: 5 }} gutterBottom>
+          {version ? `v${version}` : null}
+        </Typography>
+      </Container>
+    </>
   );
 };
 

--- a/apps/admin-web/src/app/components/Header.tsx
+++ b/apps/admin-web/src/app/components/Header.tsx
@@ -1,14 +1,16 @@
 import { useState } from 'react';
-import AppBar from '@mui/material/AppBar';
-import Box from '@mui/material/Box';
-import Toolbar from '@mui/material/Toolbar';
-import IconButton from '@mui/material/IconButton';
-import Typography from '@mui/material/Typography';
-import Menu from '@mui/material/Menu';
+import {
+  AppBar,
+  Box,
+  Toolbar,
+  IconButton,
+  Typography,
+  Menu,
+  Container,
+  Button,
+  MenuItem,
+} from '@mui/material';
 import MenuIcon from '@mui/icons-material/Menu';
-import Container from '@mui/material/Container';
-import Button from '@mui/material/Button';
-import MenuItem from '@mui/material/MenuItem';
 import { MEZZO_API_PATH } from '@caribou-crew/mezzo-constants';
 import { ReactComponent as Logo } from '../../assets/logo.svg';
 import GitHubIcon from '@mui/icons-material/GitHub';
@@ -52,7 +54,7 @@ export default function Headers(props: Props) {
   };
 
   return (
-    <AppBar position="static" sx={{ mb: 5 }}>
+    <AppBar position="relative">
       <Container maxWidth="xl">
         <Toolbar disableGutters>
           <Typography

--- a/apps/admin-web/src/app/components/RouteCategory.tsx
+++ b/apps/admin-web/src/app/components/RouteCategory.tsx
@@ -1,4 +1,4 @@
-import { Container, Typography } from '@mui/material';
+import { Grid, Typography } from '@mui/material';
 
 import { RouteItemType, VariantCategory } from '@caribou-crew/mezzo-interfaces';
 import VariantButton from './VariantButton';
@@ -25,24 +25,21 @@ const RouteCategory = ({
       <Typography variant="subtitle2" sx={{ pt: 2 }}>
         {category?.name ?? 'Variants'}
       </Typography>
-      <Container
-        disableGutters
-        sx={{
-          ml: 8,
-        }}
-      >
+      <Grid container spacing={1} sx={{ mb: 1 }}>
         {route.variants
           .filter((v) => v.category === category?.name)
-          .map((variant, idx) => (
-            <VariantButton
-              key={`${route.id}:${variant.id}`}
-              activeVariant={activeVariant}
-              setActiveVariant={setActiveVariant}
-              route={route}
-              variant={variant}
-            />
+          .map((variant, index) => (
+            <Grid key={index} item xs={12} sm={12} md={6}>
+              <VariantButton
+                key={`${route.id}:${variant.id}`}
+                activeVariant={activeVariant}
+                setActiveVariant={setActiveVariant}
+                route={route}
+                variant={variant}
+              />
+            </Grid>
           ))}
-      </Container>
+      </Grid>
     </>
   );
 };

--- a/apps/admin-web/src/app/components/RouteItem.tsx
+++ b/apps/admin-web/src/app/components/RouteItem.tsx
@@ -119,8 +119,8 @@ const RouteItem = ({
   const _renderInteractiveButtons = () => {
     return (
       <Box sx={{ display: 'flex', flexDirection: 'row' }}>
-        {route?.titleIcons?.map((icon) => (
-          <GetLinkableIcon {...icon} />
+        {route?.titleIcons?.map((icon, index) => (
+          <GetLinkableIcon key={`${icon.name}:${index}`} {...icon} />
         ))}
         <Button
           variant="contained"
@@ -154,6 +154,7 @@ const RouteItem = ({
           <OpenInNew />
         </Button>
         <Container
+          disableGutters
           sx={{
             backgroundColor: getColors().textColor,
             pt: '15px',
@@ -209,8 +210,9 @@ const RouteItem = ({
               Active Variant Id:{' '}
               {<span style={{ color: 'green' }}>{activeVariant}</span>}
             </Typography>
-            {variantCategories.map((category) => (
+            {variantCategories.map((category, index) => (
               <RouteCategory
+                key={`${category}:${index}`}
                 category={category}
                 route={route}
                 activeVariant={activeVariant}

--- a/apps/admin-web/src/app/components/VariantButton.tsx
+++ b/apps/admin-web/src/app/components/VariantButton.tsx
@@ -20,11 +20,9 @@ export default function VariantButton(props: Props) {
   return (
     <Button
       variant="contained"
+      fullWidth
       sx={{
         backgroundColor: activeRouteVariant ? blue[900] : blue[300],
-        width: '40%',
-        mr: '1%',
-        mb: 1,
       }}
       onClick={() => {
         const myVariants: SetRouteVariant = [


### PR DESCRIPTION
Fixed Keys Issue
closes #70

Additionally, Made adjustments to styling so that the screen scales down to smaller sizes better. Noticed this when working with Mezzo in split screen and smaller. Can scale down to 345px width with little overflow.

![styleAdjustment1 ](https://user-images.githubusercontent.com/46030941/165805004-602df33d-d8cf-4ee0-9b3e-f8af111cf677.png)
![styleAdjustment2](https://user-images.githubusercontent.com/46030941/165805006-35132313-b104-43cf-b45b-0b57d12b1b28.png)
![styleAdjustment3](https://user-images.githubusercontent.com/46030941/165805008-65f3244c-4a83-46a9-a650-402dda1fcd4a.png)
![styleAdjustment4](https://user-images.githubusercontent.com/46030941/165805009-8a1e76a8-cc30-4986-8cef-8429fc4a86fa.png)
