### PR TITLE
fix(mezzo-client): support relative url path for client connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This project was generated using [Nx](https://nx.dev).
 
 The only non-intuitive piece during building vs development is in development the admin website and core APIs exist on two separate ports by 2 separate projects.
 When building to publish to npm the web project is actually injected into the core project so that it is served by the same express server powering the core module.
-This is done under the hood by the `nx prepare core` step powered bythe buildCoreWithWeb/impl file.
+This is done under the hood by the `nx prepare core-server` step powered bythe buildCoreWithWeb/impl file.
 If changes are made to that file compile it `npx tsc tools/executors/buildCoreWithWeb/impl` via `npm run build:executor`. It may mention a couple tsc errors but confirm it compiles by running `git status` (the file `tools/executors/buildCoreWithWeb/impl.js` should be updated).
 
 # Commiting
@@ -34,9 +34,7 @@ This repo uses conventional commits, an easy interactive way to stay compliant i
 
 This project uses https://github.com/jscutlery/semver, currently in synced mode.
 
-Release workspace by running `npm run bumpVersion`
-
-Run `npm publish dist/libs/core-server --access public` from the root of the project, but CI will push it all when a release is made.
+Run the "Bump Vesion and Create Release" GitHub actions job to bump the version and publish to npm.
 
 # Test
 

--- a/apps/admin-web/src/app/components/RecordScreen.tsx
+++ b/apps/admin-web/src/app/components/RecordScreen.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
 
 import { Button, Container, Typography } from '@mui/material';
-import { MEZZO_API_GET_RECORDINGS } from '@caribou-crew/mezzo-constants';
 
 import { RecordedItem } from '@caribou-crew/mezzo-interfaces';
 import NetworkItem from './NetworkItem';

--- a/apps/admin-web/src/app/hooks/useFetchRoutes.ts
+++ b/apps/admin-web/src/app/hooks/useFetchRoutes.ts
@@ -17,7 +17,9 @@ export default function useFetchRoutes() {
   const [variantCategories, setVariantCategories] = useState<VariantCategory[]>(
     []
   );
-  const client = mezzoClient();
+  const client = mezzoClient({
+    useRelativeUrl: true,
+  });
 
   useEffect(() => {
     const fetchData = async () => {

--- a/apps/admin-web/src/app/hooks/useRecordingClient.ts
+++ b/apps/admin-web/src/app/hooks/useRecordingClient.ts
@@ -83,6 +83,7 @@ export default function useRecordingClient() {
 
     if (mezzoClient.current == null) {
       const mc = MezzoClient({
+        useRelativeUrl: true,
         createSocket: (path?: string) => new WebSocket(path ?? ''),
         name: 'Admin Web',
         onCommand,

--- a/libs/core-client/src/lib/__tests__/restClient.spec.ts
+++ b/libs/core-client/src/lib/__tests__/restClient.spec.ts
@@ -4,7 +4,57 @@ import MezzoClient from '../core-client';
 import { X_REQUEST_SESSION } from '@caribou-crew/mezzo-constants';
 // import { corePort } from './testPorts';
 
-describe('client route utils', () => {
+describe('restClient connection options', () => {
+  let client: ReturnType<typeof MezzoClient>;
+
+  beforeEach(() => {
+    client = MezzoClient();
+  });
+
+  it('should allow relative URLs', () => {
+    client = MezzoClient({
+      useRelativeUrl: true,
+    });
+    const url = client.getConnectionFromOptions();
+    expect(url).toBe('/_admin/api');
+  });
+  it('should construct the URL accurately', () => {
+    client = MezzoClient();
+    const url = client.getConnectionFromOptions();
+    expect(url).toBe('http://localhost:8000/_admin/api');
+  });
+  it('should allow for no port', () => {
+    client = MezzoClient({
+      port: null,
+    });
+    const url = client.getConnectionFromOptions();
+    expect(url).toBe('http://localhost/_admin/api');
+  });
+  it('secure domain with no port', () => {
+    client = MezzoClient({
+      port: null,
+      hostname: 'www.example.com',
+      secure: true,
+    });
+    const url = client.getConnectionFromOptions();
+    expect(url).toBe('https://www.example.com/_admin/api');
+  });
+  it('should allow overwiting clinet options at the function level', () => {
+    client = MezzoClient({
+      port: 8080,
+      hostname: 'localhost',
+      secure: true,
+    });
+    const url = client.getConnectionFromOptions({
+      port: 8081,
+      hostname: '127.0.0.1',
+      secure: false,
+    });
+    expect(url).toBe('http://127.0.0.1:8081/_admin/api');
+  });
+});
+
+describe('restClient', () => {
   let request: SuperTestRequest.SuperTest<SuperTestRequest.Test>;
   beforeAll(() => {
     // global.console = require('console'); // Don't stack trace out all console logs
@@ -25,7 +75,6 @@ describe('client route utils', () => {
   beforeEach(async () => {
     process.env.LOG_LEVEL = 'warn';
     const port = 3020;
-    // client = new MezzoClient({ port });
     client = MezzoClient({ port });
     request = SuperTestRequest(`http://localhost:${port}`);
     await mezzo.start({

--- a/libs/core-client/src/lib/core-client.ts
+++ b/libs/core-client/src/lib/core-client.ts
@@ -1,7 +1,7 @@
 import { IClientOptions } from '@caribou-crew/mezzo-interfaces';
 import * as log from 'loglevel';
 import { webSocketClient } from './plugins/webSocketClient';
-import { RESTClient } from './plugins/restClient';
+import { restClient as createRestClient } from './plugins/restClient';
 
 log.setDefaultLevel('debug');
 
@@ -11,6 +11,7 @@ const DEFAULT_OPTIONS: IClientOptions = {
   port: 8000,
   name: 'mezzo-core-client',
   secure: false,
+  useRelativeUrl: false,
   onCommand: () => null,
   onConnect: () => null,
   onDisconnect: () => null,
@@ -25,7 +26,7 @@ export default function mezzoClient(clientOptions?: IClientOptions) {
   log.debug('MC with options: ', options);
 
   const wsClient = webSocketClient(options);
-  const restClient = new RESTClient(options);
+  const restClient = createRestClient(options);
 
   return {
     setMockVariant: restClient.setMockVariant,
@@ -41,6 +42,7 @@ export default function mezzoClient(clientOptions?: IClientOptions) {
     getLocalProfiles: restClient.getLocalProfiles,
     getRecordings: restClient.getRecordings,
     deleteRecordings: restClient.deleteRecordings,
+    getConnectionFromOptions: restClient.getConnectionFromOptions,
 
     send: wsClient.send,
     captureApiRequest: wsClient.captureApiRequest,

--- a/libs/core-client/src/lib/plugins/restClient.ts
+++ b/libs/core-client/src/lib/plugins/restClient.ts
@@ -13,6 +13,8 @@ import {
   RecordedItem,
 } from '@caribou-crew/mezzo-interfaces';
 import axios from 'axios';
+import * as log from 'loglevel';
+log.setDefaultLevel('debug');
 
 export interface IMezzoRouteClient {
   setMockVariant: (payload: SetRouteVariant) => Promise<void>;
@@ -22,122 +24,136 @@ export interface IMezzoRouteClient {
   ) => Promise<void>;
 }
 
-export class RESTClient {
-  options: IRESTClientOptions;
+export function restClient(clientOptions: IRESTClientOptions) {
+  log.debug('Setting options as: ', clientOptions);
 
-  constructor(options: IRESTClientOptions) {
-    this.options = options;
-  }
-
-  getConnectionFromOptions(options?: IRESTClientOptions) {
+  const getConnectionFromOptions = (
+    options: IRESTClientOptions = clientOptions
+  ) => {
+    log.debug('Reading options as', options);
+    if (options?.useRelativeUrl) {
+      return MEZZO_API_PATH;
+    }
     const protocol = options?.secure ? 'https' : 'http';
     const hostname = options?.hostname ?? LOCAL_HOST;
-    const port = options?.port ?? this.options.port;
-    return `${protocol}://${hostname}:${port}${MEZZO_API_PATH}`;
-  }
+    const portValue = options?.port ?? clientOptions?.port;
+    const portIfDefined = portValue === null ? '' : `:${portValue}`;
+    // return `${protocol}://${hostname}:${port}${MEZZO_API_PATH}`;
+    return `${protocol}://${hostname}${portIfDefined}${MEZZO_API_PATH}`;
+  };
 
-  public setMockVariant = async (
+  const setMockVariant = async (
     payload: SetRouteVariant,
-    options: IRESTClientOptions = this.options
+    options?: IRESTClientOptions
   ) => {
-    const baseUri = this.getConnectionFromOptions(options);
+    const baseUri = getConnectionFromOptions(options);
     const url = `${baseUri}/routeVariants/set`;
     await axios.post(url, payload);
   };
 
-  public setMockVariantForSession = async (
+  const setMockVariantForSession = async (
     sessionId: string,
     payload: SetRouteVariant,
-    options: IRESTClientOptions = this.options
+    options?: IRESTClientOptions
   ) => {
-    const baseUri = this.getConnectionFromOptions(options);
+    const baseUri = getConnectionFromOptions(options);
     const url = `${baseUri}/sessionVariantState/set/${sessionId}`;
     await axios.post(url, payload);
   };
 
-  public updateMockVariant = async (
+  const updateMockVariant = async (
     payload: SetRouteVariant,
-    options: IRESTClientOptions = this.options
+    options?: IRESTClientOptions
   ) => {
-    const baseUri = this.getConnectionFromOptions(options);
+    const baseUri = getConnectionFromOptions(options);
     const url = `${baseUri}/routeVariants/update`;
     await axios.post(url, payload);
   };
 
-  public updateMockVariantForSession = async (
+  const updateMockVariantForSession = async (
     sessionId: string,
     payload: SetRouteVariant,
-    options: IRESTClientOptions = this.options
+    options?: IRESTClientOptions
   ) => {
-    const baseUri = this.getConnectionFromOptions(options);
+    const baseUri = getConnectionFromOptions(options);
     const url = `${baseUri}/sessionVariantState/update/${sessionId}`;
     await axios.post(url, payload);
   };
 
-  public resetMockVariant = async (
-    options: IRESTClientOptions = this.options
-  ) => {
-    const baseUri = this.getConnectionFromOptions(options);
+  const resetMockVariant = async (options?: IRESTClientOptions) => {
+    const baseUri = getConnectionFromOptions(options);
     const url = `${baseUri}/routeVariants`;
     await axios.delete(url);
   };
 
-  public resetMockVariantForSession = async (
+  const resetMockVariantForSession = async (
     sessionId: string,
-    options: IRESTClientOptions = this.options
+    options?: IRESTClientOptions
   ) => {
-    const baseUri = this.getConnectionFromOptions(options);
+    const baseUri = getConnectionFromOptions(options);
     const url = `${baseUri}/sessionVariantState/${sessionId}`;
     await axios.delete(url);
   };
 
-  public resetMockVariantForAllSessions = async (
-    options: IRESTClientOptions = this.options
+  const resetMockVariantForAllSessions = async (
+    options?: IRESTClientOptions
   ) => {
-    const baseUri = this.getConnectionFromOptions(options);
+    const baseUri = getConnectionFromOptions(options);
     const url = `${baseUri}/sessionVariantState`;
     await axios.delete(url);
   };
 
-  public getRoutes = async (options: IRESTClientOptions = this.options) => {
-    const baseUri = this.getConnectionFromOptions(options);
+  const getRoutes = async (options?: IRESTClientOptions) => {
+    const baseUri = getConnectionFromOptions(options);
     const url = `${baseUri}/routes`;
+    // const url = `/routes`;
     return axios.get<GetRoutesResponse>(url);
   };
 
-  public getActiveVariants = async (
-    options: IRESTClientOptions = this.options
-  ) => {
-    const baseUri = this.getConnectionFromOptions(options);
+  const getActiveVariants = async (options?: IRESTClientOptions) => {
+    const baseUri = getConnectionFromOptions(options);
     const url = `${baseUri}/activeVariants`;
     return axios.get<GetActiveVariantsResponse>(url);
   };
 
-  public getRemoteProfiles = async (
-    options: IRESTClientOptions = this.options
-  ) => {
-    const baseUri = this.getConnectionFromOptions(options);
+  const getRemoteProfiles = async (options?: IRESTClientOptions) => {
+    const baseUri = getConnectionFromOptions(options);
     const url = `${baseUri}/profiles`;
     return axios.get<ProfileResponse>(url);
   };
 
-  public getLocalProfiles = () => {
+  const getLocalProfiles = () => {
     const data: Profile[] =
       JSON.parse(localStorage.getItem(PROFILE_NAMESPACE) || '[]') ?? [];
     return data;
   };
 
-  public getRecordings = async (options: IRESTClientOptions = this.options) => {
-    const baseUri = this.getConnectionFromOptions(options);
+  const getRecordings = async (options?: IRESTClientOptions) => {
+    const baseUri = getConnectionFromOptions(options);
     const url = `${baseUri}/recordings`;
     return axios.get<{ items: RecordedItem[] }>(url);
   };
 
-  public deleteRecordings = async (
-    options: IRESTClientOptions = this.options
-  ) => {
-    const baseUri = this.getConnectionFromOptions(options);
+  const deleteRecordings = async (options?: IRESTClientOptions) => {
+    const baseUri = getConnectionFromOptions(options);
     const url = `${baseUri}/recordings`;
     return axios.delete(url);
+  };
+
+  return {
+    getConnectionFromOptions,
+    setMockVariant,
+    setMockVariantForSession,
+    updateMockVariant,
+    updateMockVariantForSession,
+    resetMockVariant,
+    resetMockVariantForSession,
+    resetMockVariantForAllSessions,
+    getRoutes,
+    getActiveVariants,
+    getRemoteProfiles,
+    getLocalProfiles,
+    getRecordings,
+    deleteRecordings,
   };
 }

--- a/libs/core-client/src/lib/plugins/webSocketClient.ts
+++ b/libs/core-client/src/lib/plugins/webSocketClient.ts
@@ -77,7 +77,7 @@ export function webSocketClient(options: IWebSocketClientOptions) {
     isConnected = true;
     const {
       createSocket,
-      secure,
+      useRelativeUrl,
       hostname,
       environment,
       port,
@@ -89,7 +89,24 @@ export function webSocketClient(options: IWebSocketClientOptions) {
       onDisconnect,
     } = options;
 
-    const location = `ws://${hostname}:${port}`;
+    let location = `ws://${hostname}:${port}`;
+    if (useRelativeUrl) {
+      // host: "localhost:4200"
+      // hostname: "localhost"
+      // href: "http://localhost:4200/mezzo/record"
+      // origin: "http://localhost:4200"
+      // pathname: "/mezzo/record"
+      // port: "4200"
+      // protocol: "http:"
+
+      if (process.env['NODE_ENV'] === 'production') {
+        // works in prod since web & core-server are same host
+        location = `ws://${window.location.host}`;
+      } else {
+        // Works in dev since web and core-server are on separate hosts
+        location = `ws://${window.location.hostname}:${port}`;
+      }
+    }
 
     if (!createSocket) {
       log.error(

--- a/libs/interfaces/src/lib/clientInterfaces.ts
+++ b/libs/interfaces/src/lib/clientInterfaces.ts
@@ -29,6 +29,12 @@ export interface ISharedClientOptions {
    * prior implementations were useHttps
    */
   secure?: boolean;
+
+  /**
+   * Will relative urls be used?
+   * If so host, port, and secure properties are ignored
+   */
+  useRelativeUrl?: boolean;
 }
 
 export type IRESTClientOptions = ISharedClientOptions;


### PR DESCRIPTION
When the server/client combo was hosted remotely or in a dynamic location the client would still
default to localhost:8000, now it can support relative URL to use wherever it is hosted if desired.

closes #127