### PR TITLE
fix: improve profiles page load by ~8s with 200 more routes

### DIFF
--- a/apps/admin-web/src/app/app.tsx
+++ b/apps/admin-web/src/app/app.tsx
@@ -1,5 +1,4 @@
-import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom';
-import { createContext } from 'react';
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 
 import { CssBaseline } from '@mui/material';
 import Header from './components/Header';
@@ -13,9 +12,6 @@ import mezzoClient from '@caribou-crew/mezzo-core-client';
 // If prod, routes are /mezzo and /mezzo/record instead of / and /record
 export const App = () => {
   const client = mezzoClient();
-  // const MyContext = React.createContext(client);
-
-  console.log('=============RERENDER APP ROOT');
   return (
     <Router basename={PUBLIC_URL}>
       <CssBaseline />

--- a/apps/admin-web/src/app/app.tsx
+++ b/apps/admin-web/src/app/app.tsx
@@ -1,4 +1,5 @@
 import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom';
+import { createContext } from 'react';
 
 import { CssBaseline } from '@mui/material';
 import Header from './components/Header';
@@ -6,18 +7,26 @@ import HomeScreen from './components/HomeScreen';
 import RecordScreen from './components/RecordScreen';
 import { PUBLIC_URL } from './utils/urlPrefix';
 import ProfilesScreen from './components/Profiles/ProfilesScreen';
+import { ClientContext } from './context';
+import mezzoClient from '@caribou-crew/mezzo-core-client';
 
 // If prod, routes are /mezzo and /mezzo/record instead of / and /record
 export const App = () => {
+  const client = mezzoClient();
+  // const MyContext = React.createContext(client);
+
+  console.log('=============RERENDER APP ROOT');
   return (
     <Router basename={PUBLIC_URL}>
       <CssBaseline />
       <Header name="Mezzo" />
-      <Routes>
-        <Route path="/" element={<HomeScreen />} />
-        <Route path="/record" element={<RecordScreen />} />
-        <Route path="/profiles" element={<ProfilesScreen />} />
-      </Routes>
+      <ClientContext.Provider value={client}>
+        <Routes>
+          <Route path="/" element={<HomeScreen />} />
+          <Route path="/record" element={<RecordScreen />} />
+          <Route path="/profiles" element={<ProfilesScreen />} />
+        </Routes>
+      </ClientContext.Provider>
     </Router>
   );
 };

--- a/apps/admin-web/src/app/components/HomeScreen.tsx
+++ b/apps/admin-web/src/app/components/HomeScreen.tsx
@@ -26,6 +26,8 @@ export default function Home(props: Props) {
 
   const { routes, version, variantCategories } = useFetchRoutes();
 
+  const setSelectedItemCallback = React.useCallback(setSelectedItem, []);
+
   const {
     routes: filteredRoutes,
     setFilterValue,
@@ -49,9 +51,9 @@ export default function Home(props: Props) {
             route={route}
             variantCategories={variantCategories}
             key={route.id}
-            selectedItem={selectedItem}
+            isSelected={route.id === selectedItem}
             initialActiveVariant={route.activeVariant}
-            setSelectedItem={(id) => setSelectedItem(id)}
+            setSelectedItem={setSelectedItemCallback} // does not trigger re-render
           ></RouteItem>
         </div>
       </Flipped>

--- a/apps/admin-web/src/app/components/HomeScreen.tsx
+++ b/apps/admin-web/src/app/components/HomeScreen.tsx
@@ -16,6 +16,7 @@ import useFetchRoutes from '../hooks/useFetchRoutes';
 import useRouteFilter from '../hooks/useRouteFilter';
 import useRouteSort from '../hooks/useRouteSort';
 import useFilterFromURL, { setURLHash } from '../hooks/useFilterFromURL';
+import PacmanLoader from 'react-spinners/PacmanLoader';
 
 type SortProperty = 'method' | 'path' | '';
 
@@ -24,7 +25,7 @@ type Props = Record<string, never>;
 export default function Home(props: Props) {
   const [selectedItem, setSelectedItem] = useState('');
 
-  const { routes, version, variantCategories } = useFetchRoutes();
+  const { routes, version, variantCategories, isLoading } = useFetchRoutes();
 
   const setSelectedItemCallback = React.useCallback(setSelectedItem, []);
 
@@ -166,29 +167,49 @@ export default function Home(props: Props) {
         </Grid>
       </Grid>
       <Divider />
-      <Typography
-        variant="h6"
-        sx={{
-          mt: 3,
-          '@media (max-width:475px)': {
-            textAlign: 'center',
-          },
-        }}
-        gutterBottom
-      >
-        Routes
-      </Typography>
-      {displayedRoutes.length > 0 ? (
-        <Flipper
-          flipKey={displayedRoutes.reduce(
-            (prev, current) => prev + current.id,
-            ''
-          )}
-        >
-          {renderRouteList()}
-        </Flipper>
+
+      {isLoading ? (
+        <PacmanLoader
+          // color={'#ea82e5'}
+          // color={'#46bfee'}
+          // color={'#d03e19'}
+          color={'#db851c'}
+          // color={'#fdff00'}
+          loading={isLoading}
+          css={`
+            display: block;
+            margin: 0 auto;
+            padding: 80;
+          `}
+          size={80}
+        />
       ) : (
-        _renderTypography()
+        <>
+          <Typography
+            variant="h6"
+            sx={{
+              mt: 3,
+              '@media (max-width:475px)': {
+                textAlign: 'center',
+              },
+            }}
+            gutterBottom
+          >
+            Routes
+          </Typography>
+          {displayedRoutes.length > 0 ? (
+            <Flipper
+              flipKey={displayedRoutes.reduce(
+                (prev, current) => prev + current.id,
+                ''
+              )}
+            >
+              {renderRouteList()}
+            </Flipper>
+          ) : (
+            _renderTypography()
+          )}
+        </>
       )}
       <Typography align="center" sx={{ mt: 5 }} gutterBottom>
         {version ? `v${version}` : null}

--- a/apps/admin-web/src/app/components/HomeScreen.tsx
+++ b/apps/admin-web/src/app/components/HomeScreen.tsx
@@ -170,11 +170,7 @@ export default function Home(props: Props) {
 
       {isLoading ? (
         <PacmanLoader
-          // color={'#ea82e5'}
-          // color={'#46bfee'}
-          // color={'#d03e19'}
           color={'#db851c'}
-          // color={'#fdff00'}
           loading={isLoading}
           css={`
             display: block;

--- a/apps/admin-web/src/app/components/Profiles/DeleteProfileButton.tsx
+++ b/apps/admin-web/src/app/components/Profiles/DeleteProfileButton.tsx
@@ -1,0 +1,34 @@
+import { DeleteForever } from '@mui/icons-material';
+import {
+  deleteLocalProfile,
+  getLocalProfiles,
+} from '../../utils/profileHelper';
+import { IconButton } from '@mui/material';
+import { Profile } from '@caribou-crew/mezzo-interfaces';
+
+const DeleteProfileButton = ({
+  profile,
+  setLocalProfiles,
+}: {
+  profile: Profile;
+  setLocalProfiles: (arg0: Profile[]) => void;
+}) => {
+  return (
+    <IconButton
+      color="error"
+      onClick={() => {
+        const shouldDelete = window.confirm(
+          'Are you sure you want to remove profile: ' + profile.name
+        );
+        if (shouldDelete) {
+          deleteLocalProfile(profile.name);
+          const localProfiles = getLocalProfiles();
+          setLocalProfiles(localProfiles);
+        }
+      }}
+    >
+      <DeleteForever />
+    </IconButton>
+  );
+};
+export default DeleteProfileButton;

--- a/apps/admin-web/src/app/components/Profiles/ProfileButton.tsx
+++ b/apps/admin-web/src/app/components/Profiles/ProfileButton.tsx
@@ -1,0 +1,36 @@
+import { Profile } from '@caribou-crew/mezzo-interfaces';
+import mezzoClient from '@caribou-crew/mezzo-core-client';
+import { IconButton } from '@mui/material';
+import { CheckBox, CheckBoxOutlineBlank } from '@mui/icons-material';
+
+const ProfileButton = ({
+  setSelectedProfile,
+  setMatchedProfile,
+  client,
+  profile,
+  selectedProfile,
+}: {
+  profile: Profile;
+  client: ReturnType<typeof mezzoClient>;
+  setMatchedProfile: (arg0: string) => void;
+  setSelectedProfile: (arg0: string) => void;
+  selectedProfile: string;
+}) => {
+  return (
+    <IconButton
+      color="primary"
+      onClick={() => {
+        client.setMockVariant(profile.variants);
+        setSelectedProfile(profile.name);
+        setMatchedProfile(profile.name);
+      }}
+    >
+      {selectedProfile === profile.name ? (
+        <CheckBox />
+      ) : (
+        <CheckBoxOutlineBlank />
+      )}
+    </IconButton>
+  );
+};
+export default ProfileButton;

--- a/apps/admin-web/src/app/components/Profiles/ProfileDetails.tsx
+++ b/apps/admin-web/src/app/components/Profiles/ProfileDetails.tsx
@@ -1,0 +1,138 @@
+import React from 'react';
+import mezzoClient from '@caribou-crew/mezzo-core-client';
+import {
+  Container,
+  Typography,
+  IconButton,
+  Box,
+  Paper,
+  Divider,
+} from '@mui/material';
+import { Profile } from '@caribou-crew/mezzo-interfaces';
+import { ExpandMore, ExpandLess } from '@mui/icons-material';
+import ProfileButton from './ProfileButton';
+import DeleteProfileButton from './DeleteProfileButton';
+
+interface DetailsExpanded {
+  profileName: string;
+  isExpanded: boolean;
+}
+const ProfileDetails = ({
+  profile,
+  type,
+  setSelectedProfile,
+  setMatchedProfile,
+  client,
+  selectedProfile,
+  setLocalProfiles,
+  setDetailsExpanded,
+  detailsExpanded,
+}: {
+  profile: Profile;
+  type: string;
+  setLocalProfiles: (arg0: Profile[]) => void;
+  setDetailsExpanded: (arg0: DetailsExpanded) => void;
+
+  client: ReturnType<typeof mezzoClient>;
+  setMatchedProfile: (arg0: string) => void;
+  setSelectedProfile: (arg0: string) => void;
+  selectedProfile: string;
+  detailsExpanded: DetailsExpanded;
+}) => {
+  return (
+    <Paper key={profile.name} sx={{ mb: 1.5 }}>
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'row',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+        }}
+      >
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'row',
+            alignItems: 'center',
+          }}
+        >
+          <ProfileButton
+            setSelectedProfile={setSelectedProfile}
+            setMatchedProfile={setMatchedProfile}
+            profile={profile}
+            client={client}
+            selectedProfile={selectedProfile}
+          />
+          <Typography variant="subtitle1">{profile.name}</Typography>
+        </Box>
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'row',
+            alignItems: 'center',
+          }}
+        >
+          {/* {type === 'local' && _renderDeleteLocalProfileButton(profile)} */}
+          {type === 'local' && (
+            <DeleteProfileButton
+              profile={profile}
+              setLocalProfiles={setLocalProfiles}
+            />
+          )}
+          <IconButton
+            onClick={() => {
+              profile.name === detailsExpanded.profileName
+                ? setDetailsExpanded({
+                    profileName: '',
+                    isExpanded: false,
+                  })
+                : setDetailsExpanded({
+                    profileName: profile.name,
+                    isExpanded: !detailsExpanded,
+                  });
+            }}
+          >
+            {detailsExpanded.profileName === profile.name &&
+            !detailsExpanded.isExpanded ? (
+              <ExpandLess />
+            ) : (
+              <ExpandMore />
+            )}
+          </IconButton>
+        </Box>
+      </Box>
+      {detailsExpanded.profileName === profile.name && (
+        <>
+          <Divider />
+          <Container sx={{ mt: 1, pb: 2 }}>
+            <Typography variant="subtitle2" component="p">
+              Routes:
+            </Typography>
+            {profile.variants.map((i) => (
+              <>
+                <Typography
+                  variant="subtitle2"
+                  component="p"
+                  noWrap
+                  sx={{ ml: 2, mt: 0.5 }}
+                >
+                  {i.routeID}
+                </Typography>
+                <Typography
+                  variant="subtitle2"
+                  component="p"
+                  noWrap
+                  sx={{ ml: 6, mt: 0.5 }}
+                >
+                  Variant: {i.variantID}
+                </Typography>
+              </>
+            ))}
+          </Container>
+        </>
+      )}
+    </Paper>
+  );
+};
+
+export default ProfileDetails;

--- a/apps/admin-web/src/app/components/Profiles/ProfileDetails.tsx
+++ b/apps/admin-web/src/app/components/Profiles/ProfileDetails.tsx
@@ -72,7 +72,6 @@ const ProfileDetails = ({
             alignItems: 'center',
           }}
         >
-          {/* {type === 'local' && _renderDeleteLocalProfileButton(profile)} */}
           {type === 'local' && (
             <DeleteProfileButton
               profile={profile}

--- a/apps/admin-web/src/app/components/Profiles/ProfilesScreen.tsx
+++ b/apps/admin-web/src/app/components/Profiles/ProfilesScreen.tsx
@@ -1,49 +1,30 @@
 import React, { useContext, useEffect, useState } from 'react';
 
-import {
-  Container,
-  Typography,
-  IconButton,
-  Box,
-  Paper,
-  Divider,
-} from '@mui/material';
-import {
-  CheckBox,
-  CheckBoxOutlineBlank,
-  DeleteForever,
-  Save,
-  ExpandMore,
-  ExpandLess,
-  CopyAll,
-} from '@mui/icons-material';
-import useFetchRoutes from '../../hooks/useFetchRoutes';
+import { Container, Typography, Paper } from '@mui/material';
 import { Profile, RouteVariant } from '@caribou-crew/mezzo-interfaces';
-// import mezzoClient from '@caribou-crew/mezzo-core-client';
-import {
-  deleteLocalProfile,
-  getLocalProfiles,
-  saveLocalProfile,
-} from '../../utils/profileHelper';
+import { getLocalProfiles, saveLocalProfile } from '../../utils/profileHelper';
 import { Light as SyntaxHighlighter } from 'react-syntax-highlighter';
 import js from 'react-syntax-highlighter/dist/cjs/languages/hljs/javascript';
-import github from 'react-syntax-highlighter/dist/cjs/styles/hljs/github';
-import { ToastContainer, toast } from 'react-toastify';
+import { ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 import { ClientContext } from '../../context';
 import { arraysEqual } from '../../utils/equality';
+import Variants from './Variants';
+import SaveButton from './SaveButton';
+import ProfileDetails from './ProfileDetails';
+import SaveAsRemote from './SaveAsRemote';
 
 SyntaxHighlighter.registerLanguage('javascript', js);
 
 type Props = Record<string, never>;
 
 export default function ProfilesScreen(props: Props) {
-  // const client = mezzoClient();
+  console.log('Profile Screen');
   const client = useContext(ClientContext);
-  const { routes } = useFetchRoutes();
 
   const [remoteProfiles, setRemoteProfiles] = useState<Profile[]>([]);
   const [localProfiles, setLocalProfiles] = useState<Profile[]>([]);
+  const [matchedProfile, setMatchedProfile] = useState<string | null>(null);
   const [saveAsRemote, setSaveAsRemote] = useState('');
   const [activeVariants, setActiveVariants] = useState<RouteVariant[]>([]);
 
@@ -78,269 +59,81 @@ export default function ProfilesScreen(props: Props) {
     fetchData().catch(console.error);
   }, []);
 
-  const _renderProfileButton = (profile: Profile) => {
-    return (
-      <IconButton
-        color="primary"
-        onClick={() => {
-          client.setMockVariant(profile.variants);
-          setSelectedProfile(profile.name);
-        }}
-      >
-        {selectedProfile === profile.name ? (
-          <CheckBox />
-        ) : (
-          <CheckBoxOutlineBlank />
-        )}
-      </IconButton>
-    );
-  };
-
-  const _renderDeleteLocalProfileButton = (profile: Profile) => {
-    return (
-      <IconButton
-        color="error"
-        onClick={() => {
-          const shouldDelete = window.confirm(
-            'Are you sure you want to remove profile: ' + profile.name
-          );
-          if (shouldDelete) {
-            deleteLocalProfile(profile.name);
-            const localProfiles = getLocalProfiles();
-            setLocalProfiles(localProfiles);
-          }
-        }}
-      >
-        <DeleteForever />
-      </IconButton>
-    );
-  };
-
-  const _renderProfileDetails = (profile: Profile, type: string) => {
-    return (
-      <Paper key={profile.name} sx={{ mb: 1.5 }}>
-        <Box
-          sx={{
-            display: 'flex',
-            flexDirection: 'row',
-            alignItems: 'center',
-            justifyContent: 'space-between',
-          }}
-        >
-          <Box
-            sx={{
-              display: 'flex',
-              flexDirection: 'row',
-              alignItems: 'center',
-            }}
-          >
-            {_renderProfileButton(profile)}
-            <Typography variant="subtitle1">{profile.name}</Typography>
-          </Box>
-          <Box
-            sx={{
-              display: 'flex',
-              flexDirection: 'row',
-              alignItems: 'center',
-            }}
-          >
-            {type === 'local' && _renderDeleteLocalProfileButton(profile)}
-            <IconButton
-              onClick={() => {
-                profile.name === detailsExpanded.profileName
-                  ? setDetailsExpanded({
-                      profileName: '',
-                      isExpanded: false,
-                    })
-                  : setDetailsExpanded({
-                      profileName: profile.name,
-                      isExpanded: !detailsExpanded,
-                    });
-              }}
-            >
-              {detailsExpanded.profileName === profile.name &&
-              !detailsExpanded.isExpanded ? (
-                <ExpandLess />
-              ) : (
-                <ExpandMore />
-              )}
-            </IconButton>
-          </Box>
-        </Box>
-        {detailsExpanded.profileName === profile.name && (
-          <>
-            <Divider />
-            <Container sx={{ mt: 1, pb: 2 }}>
-              <Typography variant="subtitle2" component="p">
-                Routes:
-              </Typography>
-              {profile.variants.map((i) => (
-                <>
-                  <Typography
-                    variant="subtitle2"
-                    component="p"
-                    noWrap
-                    sx={{ ml: 2, mt: 0.5 }}
-                  >
-                    {i.routeID}
-                  </Typography>
-                  <Typography
-                    variant="subtitle2"
-                    component="p"
-                    noWrap
-                    sx={{ ml: 6, mt: 0.5 }}
-                  >
-                    Variant: {i.variantID}
-                  </Typography>
-                </>
-              ))}
-            </Container>
-          </>
-        )}
-      </Paper>
-    );
-  };
-
-  /**
-   * TODO optimize me, this call can take ~10 seconds if we have say 200+ routes
-   */
-  const _getMatchingProfileCheck = () => {
-    const profiles = [...remoteProfiles, ...localProfiles];
-
-    let profileName;
-    profiles.some((profile) => {
+  if (matchedProfile == null) {
+    [...remoteProfiles, ...localProfiles].some((profile) => {
       if (arraysEqual(profile.variants, activeVariants)) {
-        profileName = profile.name;
+        setMatchedProfile(profile.name);
         return true;
       }
       return false;
     });
-
-    return profileName
-      ? `Selected routes and variants match profile: ${profileName}`
-      : 'No remote profiles match these selections';
-  };
-
-  const _renderCurrentSelectedRoutes = (variant: RouteVariant) => {
-    return (
-      <Box sx={{ pt: 0.5, pb: 0.5 }}>
-        <Typography noWrap variant="body1">
-          <b>Route:</b> {variant.routeID}
-        </Typography>
-        <Typography noWrap variant="body1">
-          <b>Selected Varaint:</b> {variant.variantID}
-        </Typography>
-      </Box>
-    );
-  };
-
-  const _renderSaveButton = (type: string) => {
-    return (
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'row',
-          alignItems: 'center',
-          ml: 2,
-        }}
-      >
-        <Typography variant="body1" component="p">
-          Save as {type} profile:
-        </Typography>
-        <IconButton
-          color="primary"
-          onClick={async () => {
-            const enteredName = prompt('Please enter profile name');
-            if (enteredName) {
-              const { data } = (await client.getActiveVariants()) ?? {};
-              if (data?.variants) {
-                if (type === 'remote') {
-                  setSaveAsRemote(
-                    `mezzo.profile('${enteredName}', ${JSON.stringify(
-                      data.variants
-                    )});`
-                  );
-                } else if (type === 'local') {
-                  // Save to local
-                  saveLocalProfile({
-                    name: enteredName,
-                    // variants: [],
-                    variants: data?.variants,
-                  });
-                  const localProfiles = getLocalProfiles();
-                  setLocalProfiles(localProfiles);
-                }
-              }
-            }
-          }}
-        >
-          <Save />
-        </IconButton>
-      </Box>
-    );
-  };
+  }
 
   return (
     <Container component="main" maxWidth="lg" sx={{ marginTop: 3 }}>
       <Typography variant="h6">Current Selected Routes:</Typography>
       <Paper sx={{ pt: 1, pb: 1 }}>
         <Container>
-          {activeVariants.map((variant) =>
-            _renderCurrentSelectedRoutes(variant)
-          )}
+          <Variants variants={activeVariants} />
           <Typography sx={{ pt: 2 }} color="red">
-            {_getMatchingProfileCheck()}{' '}
+            {matchedProfile
+              ? `Selected routes and variants match profile: ${matchedProfile}`
+              : 'No remote profiles match these selections'}
           </Typography>
         </Container>
       </Paper>
-      {_renderSaveButton('local')}
-      {_renderSaveButton('remote')}
-      {saveAsRemote ? (
-        <Paper sx={{ backgroundColor: '#FFFFFF', pt: 1, pb: 1, mb: 1 }}>
-          <Container>
-            <Box
-              sx={{
-                display: 'flex',
-                flexDirection: 'row',
-                alignItems: 'center',
-              }}
-            >
-              <IconButton
-                sx={{ pl: 0 }}
-                onClick={() => {
-                  navigator.clipboard.writeText(saveAsRemote);
-                  toast.success('Copied');
-                }}
-                color="primary"
-              >
-                <CopyAll />
-              </IconButton>
-              <Typography variant="body1">
-                Copy the following code snippet to where you initialize the
-                mezzo server
-              </Typography>
-            </Box>
-            <SyntaxHighlighter
-              language="javascript"
-              style={github}
-              customStyle={{
-                padding: 0,
-                margin: 0,
-                backgroundColor: '#FFFFFF',
-              }}
-              wrapLongLines={true}
-            >
-              {saveAsRemote}
-            </SyntaxHighlighter>
-          </Container>
-        </Paper>
-      ) : null}
       <Typography variant="h6">Remote Profiles</Typography>
-      {remoteProfiles.map((profile) =>
-        _renderProfileDetails(profile, 'remote')
-      )}
+      {remoteProfiles.map((profile) => (
+        <ProfileDetails
+          type="remote"
+          profile={profile}
+          setSelectedProfile={setSelectedProfile}
+          setMatchedProfile={setMatchedProfile}
+          client={client}
+          selectedProfile={selectedProfile}
+          setLocalProfiles={setLocalProfiles}
+          setDetailsExpanded={setDetailsExpanded}
+          detailsExpanded={detailsExpanded}
+          key={profile.name}
+        />
+      ))}
       <Typography variant="h6">Local Profiles</Typography>
-      {localProfiles.map((profile) => _renderProfileDetails(profile, 'local'))}
+      {localProfiles.map((profile) => (
+        <ProfileDetails
+          type="local"
+          profile={profile}
+          setSelectedProfile={setSelectedProfile}
+          setMatchedProfile={setMatchedProfile}
+          client={client}
+          selectedProfile={selectedProfile}
+          setLocalProfiles={setLocalProfiles}
+          setDetailsExpanded={setDetailsExpanded}
+          detailsExpanded={detailsExpanded}
+          key={profile.name}
+        />
+      ))}
+      <SaveButton
+        type="local"
+        client={client}
+        onSave={(name, variants) => {
+          saveLocalProfile({
+            name,
+            variants,
+          });
+          const localProfiles = getLocalProfiles();
+          setLocalProfiles(localProfiles);
+        }}
+      />
+      <SaveButton
+        type="remote"
+        client={client}
+        onSave={(name, variants) => {
+          setSaveAsRemote(
+            `mezzo.profile('${name}', ${JSON.stringify(variants)});`
+          );
+        }}
+      />
+      <SaveAsRemote saveAsRemote={saveAsRemote} />
       <ToastContainer
         position="bottom-center"
         autoClose={2000}

--- a/apps/admin-web/src/app/components/Profiles/ProfilesScreen.tsx
+++ b/apps/admin-web/src/app/components/Profiles/ProfilesScreen.tsx
@@ -19,7 +19,7 @@ import {
 } from '@mui/icons-material';
 import useFetchRoutes from '../../hooks/useFetchRoutes';
 import { Profile, RouteVariant } from '@caribou-crew/mezzo-interfaces';
-import mezzoClient from '@caribou-crew/mezzo-core-client';
+// import mezzoClient from '@caribou-crew/mezzo-core-client';
 import {
   deleteLocalProfile,
   getLocalProfiles,
@@ -30,7 +30,7 @@ import js from 'react-syntax-highlighter/dist/cjs/languages/hljs/javascript';
 import github from 'react-syntax-highlighter/dist/cjs/styles/hljs/github';
 import { ToastContainer, toast } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
-// import { ClientContext } from '../../context';
+import { ClientContext } from '../../context';
 import { arraysEqual } from '../../utils/equality';
 
 SyntaxHighlighter.registerLanguage('javascript', js);
@@ -38,8 +38,8 @@ SyntaxHighlighter.registerLanguage('javascript', js);
 type Props = Record<string, never>;
 
 export default function ProfilesScreen(props: Props) {
-  const client = mezzoClient();
-  // const client = useContext(ClientContext);
+  // const client = mezzoClient();
+  const client = useContext(ClientContext);
   const { routes } = useFetchRoutes();
 
   const [remoteProfiles, setRemoteProfiles] = useState<Profile[]>([]);

--- a/apps/admin-web/src/app/components/Profiles/ProfilesScreen.tsx
+++ b/apps/admin-web/src/app/components/Profiles/ProfilesScreen.tsx
@@ -19,7 +19,6 @@ SyntaxHighlighter.registerLanguage('javascript', js);
 type Props = Record<string, never>;
 
 export default function ProfilesScreen(props: Props) {
-  console.log('Profile Screen');
   const client = useContext(ClientContext);
 
   const [remoteProfiles, setRemoteProfiles] = useState<Profile[]>([]);

--- a/apps/admin-web/src/app/components/Profiles/SaveAsRemote.tsx
+++ b/apps/admin-web/src/app/components/Profiles/SaveAsRemote.tsx
@@ -1,0 +1,53 @@
+import { Container, Typography, IconButton, Box, Paper } from '@mui/material';
+import { CopyAll } from '@mui/icons-material';
+import { Light as SyntaxHighlighter } from 'react-syntax-highlighter';
+import github from 'react-syntax-highlighter/dist/cjs/styles/hljs/github';
+import { toast } from 'react-toastify';
+
+const SaveAsRemote = ({ saveAsRemote }: { saveAsRemote: string }) => {
+  if (saveAsRemote.length === 0) {
+    return null;
+  }
+  return (
+    <Paper sx={{ backgroundColor: '#FFFFFF', pt: 1, pb: 1, mb: 1 }}>
+      <Container>
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'row',
+            alignItems: 'center',
+          }}
+        >
+          <IconButton
+            sx={{ pl: 0 }}
+            onClick={() => {
+              navigator.clipboard.writeText(saveAsRemote);
+              toast.success('Copied');
+            }}
+            color="primary"
+          >
+            <CopyAll />
+          </IconButton>
+          <Typography variant="body1">
+            Copy the following code snippet to where you initialize the mezzo
+            server
+          </Typography>
+        </Box>
+        <SyntaxHighlighter
+          language="javascript"
+          style={github}
+          customStyle={{
+            padding: 0,
+            margin: 0,
+            backgroundColor: '#FFFFFF',
+          }}
+          wrapLongLines={true}
+        >
+          {saveAsRemote}
+        </SyntaxHighlighter>
+      </Container>
+    </Paper>
+  );
+};
+
+export default SaveAsRemote;

--- a/apps/admin-web/src/app/components/Profiles/SaveButton.tsx
+++ b/apps/admin-web/src/app/components/Profiles/SaveButton.tsx
@@ -1,0 +1,44 @@
+import { Typography, IconButton, Box } from '@mui/material';
+import { Save } from '@mui/icons-material';
+import { RouteVariant } from '@caribou-crew/mezzo-interfaces';
+import mezzoClient from '@caribou-crew/mezzo-core-client';
+
+const SaveButton = ({
+  type,
+  client,
+  onSave,
+}: {
+  type: string;
+  client: ReturnType<typeof mezzoClient>;
+  onSave: (name: string, variants: RouteVariant[]) => void;
+}) => {
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'row',
+        alignItems: 'center',
+        ml: 2,
+      }}
+    >
+      <Typography variant="body1" component="p">
+        Save as {type} profile:
+      </Typography>
+      <IconButton
+        color="primary"
+        onClick={async () => {
+          const enteredName = prompt('Please enter profile name');
+          if (enteredName) {
+            const { data } = (await client.getActiveVariants()) ?? {};
+            if (data?.variants) {
+              onSave(enteredName, data.variants);
+            }
+          }
+        }}
+      >
+        <Save />
+      </IconButton>
+    </Box>
+  );
+};
+export default SaveButton;

--- a/apps/admin-web/src/app/components/Profiles/Variants.tsx
+++ b/apps/admin-web/src/app/components/Profiles/Variants.tsx
@@ -1,0 +1,25 @@
+import { Typography, Box } from '@mui/material';
+import { RouteVariant } from '@caribou-crew/mezzo-interfaces';
+
+const Variants = ({ variants }: { variants: RouteVariant[] }) => (
+  <>
+    {variants.map((variant) => (
+      <Variant data={variant} key={variant.routeID} />
+    ))}
+  </>
+);
+
+export const Variant = ({ data }: { data: RouteVariant }) => {
+  return (
+    <Box sx={{ pt: 0.5, pb: 0.5 }}>
+      <Typography noWrap variant="body1">
+        <b>Route:</b> {data.routeID}
+      </Typography>
+      <Typography noWrap variant="body1">
+        <b>Selected Varaint:</b> {data.variantID}
+      </Typography>
+    </Box>
+  );
+};
+
+export default Variants;

--- a/apps/admin-web/src/app/components/RouteItem.tsx
+++ b/apps/admin-web/src/app/components/RouteItem.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import React, { useState } from 'react';
 import {
   Container,
   Button,
@@ -18,22 +18,24 @@ import {
 } from '@caribou-crew/mezzo-interfaces';
 import DynamicIcon from './DynamicIcon';
 import RouteCategory from './RouteCategory';
+// import * as log from 'loglevel';
 
 type Props = {
   route: RouteItemType;
-  selectedItem: string;
+  isSelected: boolean;
   initialActiveVariant: string;
-  setSelectedItem: (id: string) => void;
+  setSelectedItem?: (id: string) => void;
   variantCategories: VariantCategory[];
 };
 
 const RouteItem = ({
   route,
-  selectedItem,
+  isSelected,
   initialActiveVariant,
   setSelectedItem,
   variantCategories,
 }: Props) => {
+  // console.log('Re-rendering route item: ', route.id);
   const [activeVariant, setActiveVariant] = useState(initialActiveVariant);
 
   const getColors = () => {
@@ -84,7 +86,7 @@ const RouteItem = ({
             {route.path}
           </>
         </Typography>
-        {selectedItem !== route.id && activeVariant !== 'default' && (
+        {isSelected && activeVariant !== 'default' && (
           <Typography noWrap variant="body1">
             <b>Variant: </b>
             {activeVariant}
@@ -181,11 +183,9 @@ const RouteItem = ({
         cursor: 'pointer',
         marginBottom: 15,
       }}
-      onClick={() =>
-        route.id === selectedItem
-          ? setSelectedItem('')
-          : setSelectedItem(route.id)
-      }
+      onClick={() => {
+        isSelected ? setSelectedItem?.('') : setSelectedItem?.(route.id);
+      }}
     >
       <Box
         sx={{
@@ -197,7 +197,7 @@ const RouteItem = ({
         {_renderRouteTitle()}
         {_renderInteractiveButtons()}
       </Box>
-      {selectedItem === route.id && (
+      {isSelected && (
         <Box>
           <Divider></Divider>
           <Container
@@ -230,4 +230,5 @@ const RouteItem = ({
   );
 };
 
-export default RouteItem;
+// export default RouteItem;
+export default React.memo(RouteItem);

--- a/apps/admin-web/src/app/context.ts
+++ b/apps/admin-web/src/app/context.ts
@@ -1,0 +1,4 @@
+import { createContext } from 'react';
+
+import mezzoClient from '@caribou-crew/mezzo-core-client';
+export const ClientContext = createContext(mezzoClient());

--- a/apps/admin-web/src/app/hooks/useFetchRoutes.ts
+++ b/apps/admin-web/src/app/hooks/useFetchRoutes.ts
@@ -1,6 +1,7 @@
 import { RouteItemType, VariantCategory } from '@caribou-crew/mezzo-interfaces';
-import { useEffect, useState } from 'react';
-import mezzoClient from '@caribou-crew/mezzo-core-client';
+import { useContext, useEffect, useState } from 'react';
+import { ClientContext } from '../context';
+// import mezzoClient from '@caribou-crew/mezzo-core-client';
 
 export interface URLHashCallback {
   routes: RouteItemType[];
@@ -17,9 +18,11 @@ export default function useFetchRoutes() {
   const [variantCategories, setVariantCategories] = useState<VariantCategory[]>(
     []
   );
-  const client = mezzoClient({
-    useRelativeUrl: true,
-  });
+
+  const client = useContext(ClientContext);
+  // const client = mezzoClient({
+  //   useRelativeUrl: true,
+  // });
 
   useEffect(() => {
     const fetchData = async () => {

--- a/apps/admin-web/src/app/hooks/useFetchRoutes.ts
+++ b/apps/admin-web/src/app/hooks/useFetchRoutes.ts
@@ -14,6 +14,7 @@ export interface URLHashCallback {
  */
 export default function useFetchRoutes() {
   const [routes, setRoutes] = useState<RouteItemType[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
   const [version, setVersion] = useState<string>('');
   const [variantCategories, setVariantCategories] = useState<VariantCategory[]>(
     []
@@ -26,6 +27,7 @@ export default function useFetchRoutes() {
 
   useEffect(() => {
     const fetchData = async () => {
+      setIsLoading(true);
       const { data } = (await client.getRoutes()) || {};
       if (data) {
         setRoutes(data?.routes);
@@ -37,10 +39,11 @@ export default function useFetchRoutes() {
           )
         );
       }
+      setIsLoading(false);
     };
 
     fetchData().catch(console.error);
   }, []);
 
-  return { routes, version, variantCategories };
+  return { routes, version, variantCategories, isLoading };
 }

--- a/apps/admin-web/src/app/utils/equality.ts
+++ b/apps/admin-web/src/app/utils/equality.ts
@@ -1,0 +1,12 @@
+export function objectsEqual(o1: any, o2: any): boolean {
+  return typeof o1 === 'object' && Object.keys(o1).length > 0
+    ? Object.keys(o1).length === Object.keys(o2).length &&
+        Object.keys(o1).every((p) => objectsEqual(o1[p], o2[p]))
+    : o1 === o2;
+}
+
+export function arraysEqual<T>(a1: T[], a2: T[]): boolean {
+  return (
+    a1.length === a2.length && a1.every((o, idx) => objectsEqual(o, a2[idx]))
+  );
+}

--- a/libs/core-server/src/index.ts
+++ b/libs/core-server/src/index.ts
@@ -39,6 +39,31 @@ if (arg === 'start') {
         },
       ]);
 
+      for (let i = 0; i < 200; i++) {
+        mezzo
+          .route({
+            id: `GET /testing/lots/of/endpoints/${i}`,
+            path: `/testing/lots/of/endpoints/${i}`,
+            titleIcons: [
+              {
+                name: 'code',
+                link: 'https://github.com/caribou-crew/mezzo',
+              },
+            ],
+            icons: [database, dynamicFeed, link],
+            handler: function (req, res) {
+              res.json({ someKey: 'A' });
+            },
+          })
+          .variant({
+            id: 'variant1',
+            icons: [database],
+            handler: function (req, res) {
+              res.json({ someKey: 'B' });
+            },
+          });
+      }
+
       mezzo
         .route({
           id: 'GET /api/food/meat',

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "react-is": "18.1.0",
         "react-reflex": "https://github.com/caribou-crew/Re-Flex/tarball/master",
         "react-router-dom": "6.3.0",
+        "react-spinners": "^0.12.0",
         "react-syntax-highlighter": "^15.5.0",
         "react-toastify": "^9.0.1",
         "reactotron-core-client": "^2.8.10",
@@ -26232,6 +26233,18 @@
         "react": "^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/react-spinners": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/react-spinners/-/react-spinners-0.12.0.tgz",
+      "integrity": "sha512-kC/3g4Dk3kBaVfYVu7f+Zxd9wTxt6Lzws5cP3jCuE03TZwTNtwS++ZGUNF8BR3M8UrUFXP0gil0L9LONOsUkjw==",
+      "dependencies": {
+        "@emotion/react": "^11.4.1"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-syntax-highlighter": {
       "version": "15.5.0",
       "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-15.5.0.tgz",
@@ -50970,6 +50983,14 @@
       "requires": {
         "object-assign": "^4.1.1",
         "react-is": "^16.12.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "react-spinners": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/react-spinners/-/react-spinners-0.12.0.tgz",
+      "integrity": "sha512-kC/3g4Dk3kBaVfYVu7f+Zxd9wTxt6Lzws5cP3jCuE03TZwTNtwS++ZGUNF8BR3M8UrUFXP0gil0L9LONOsUkjw==",
+      "requires": {
+        "@emotion/react": "^11.4.1"
       }
     },
     "react-syntax-highlighter": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "react-is": "18.1.0",
     "react-reflex": "https://github.com/caribou-crew/Re-Flex/tarball/master",
     "react-router-dom": "6.3.0",
+    "react-spinners": "^0.12.0",
     "react-syntax-highlighter": "^15.5.0",
     "react-toastify": "^9.0.1",
     "reactotron-core-client": "^2.8.10",


### PR DESCRIPTION
Closes #139

One home page (routes) every time you expanded or collapsed a single item ALL routes would re-render.  This was visually evident with 200ish routes.  I resolved by memoizing the setState callback and instead of passing the selected route string to ALL components (changed every selection), I pulled the conditional check up to the routes page so that it only passed a boolean to each component (so that ONLY the component(s) which changed will rerender).

On profile page instead of making api call to select all routes I just make api call to get active variants, then I perform check against that.  This helped reduce time it took to process especially when there were hundreds of routes by several seconds.