### PR TITLE
fix: update host and port defaults

### DIFF
--- a/libs/core-client/src/lib/core-client.ts
+++ b/libs/core-client/src/lib/core-client.ts
@@ -6,9 +6,9 @@ import { restClient as createRestClient } from './plugins/restClient';
 log.setDefaultLevel('debug');
 
 const DEFAULT_OPTIONS: IClientOptions = {
-  hostname: 'localhost',
+  hostname: undefined,
   createSocket: undefined,
-  port: 8000,
+  port: undefined,
   name: 'mezzo-core-client',
   secure: false,
   useRelativeUrl: false,
@@ -22,6 +22,19 @@ export default function mezzoClient(clientOptions?: IClientOptions) {
     ...DEFAULT_OPTIONS,
     ...clientOptions,
   };
+
+  if (!clientOptions?.useRelativeUrl) {
+    if (
+      clientOptions?.port === undefined &&
+      clientOptions?.hostname === undefined
+    ) {
+      log.debug('Assuming localhost:8000 as no host provided');
+      options.hostname = 'localhost';
+      options.port = 8000;
+    } else if (clientOptions?.hostname === undefined) {
+      options.hostname = 'localhost';
+    }
+  }
 
   log.debug('MC with options: ', options);
 

--- a/libs/core-client/src/lib/plugins/__tests__/restClient.spec.ts
+++ b/libs/core-client/src/lib/plugins/__tests__/restClient.spec.ts
@@ -30,10 +30,11 @@ describe('restClient connection options', () => {
   });
   it('should allow for no port', () => {
     client = mezzoClient({
+      hostname: 'example.com',
       port: null,
     });
     const url = client.getConnectionFromOptions();
-    expect(url).toBe('http://localhost/_admin/api');
+    expect(url).toBe('http://example.com/_admin/api');
   });
   it('secure domain with no port', () => {
     client = mezzoClient({

--- a/libs/core-client/src/lib/plugins/restClient.ts
+++ b/libs/core-client/src/lib/plugins/restClient.ts
@@ -37,8 +37,7 @@ export function restClient(clientOptions: IRESTClientOptions) {
     const protocol = options?.secure ? 'https' : 'http';
     const hostname = options?.hostname ?? LOCAL_HOST;
     const portValue = options?.port ?? clientOptions?.port;
-    const portIfDefined = portValue === null ? '' : `:${portValue}`;
-    // return `${protocol}://${hostname}:${port}${MEZZO_API_PATH}`;
+    const portIfDefined = portValue == null ? '' : `:${portValue}`;
     return `${protocol}://${hostname}${portIfDefined}${MEZZO_API_PATH}`;
   };
 

--- a/libs/core-client/src/lib/plugins/webSocketClient.ts
+++ b/libs/core-client/src/lib/plugins/webSocketClient.ts
@@ -18,6 +18,7 @@ import debounce from 'lodash.debounce';
 // } from '@caribou-crew/mezzo-constants';
 const MEZZO_WS_API_REQUEST = 'api.request';
 const MEZZO_WS_API_RESPONSE = 'api.response';
+const DEFAULT_PORT = 8000;
 
 log.setDefaultLevel('debug');
 
@@ -81,7 +82,7 @@ export function webSocketClient(options: IWebSocketClientOptions) {
       onDisconnect,
     } = options;
 
-    let location = `ws://${hostname}:${port}`;
+    let location = `ws://${hostname}:${port ?? DEFAULT_PORT}`;
     if (useRelativeUrl) {
       // host: "localhost:4200"
       // hostname: "localhost"
@@ -96,7 +97,7 @@ export function webSocketClient(options: IWebSocketClientOptions) {
         location = `ws://${window.location.host}`;
       } else {
         // Works in dev since web and core-server are on separate hosts
-        location = `ws://${window.location.hostname}:${port}`;
+        location = `ws://${window.location.hostname}:${port ?? DEFAULT_PORT}`;
       }
     }
 


### PR DESCRIPTION
Uses logical defaults for host and port.

If neither defined use localhost 8000.  If only port is defined, assume localhost (we need something).  If host is defined but port isn't, don't use a port.