### PR TITLE
feat: show pending requests

### DIFF
--- a/apps/admin-web/src/app/components/NetworkItem.tsx
+++ b/apps/admin-web/src/app/components/NetworkItem.tsx
@@ -77,7 +77,7 @@ const NetworkItem = ({
             {deltaTime} ms
           </TableCell>
           <TableCell padding="checkbox" align="right">
-            {duration.toFixed(2)}
+            {duration?.toFixed(2)}
           </TableCell>
         </>
       )}

--- a/apps/admin-web/src/app/components/RecordScreen.tsx
+++ b/apps/admin-web/src/app/components/RecordScreen.tsx
@@ -43,6 +43,7 @@ export default function RecordScreen(props: Props) {
   const { width } = useWindowDimensions();
   const [selectedNetworkItem, setSelectedNetworkItem] =
     useState<RecordedItem>();
+  const [lastUuid, setLastUuid] = useState('');
   const { state, dispatch, mezzoClient } = useRecordingClient();
 
   const divRef = useRef<null | HTMLDivElement>(null);
@@ -82,10 +83,34 @@ export default function RecordScreen(props: Props) {
           variant="outlined"
           sx={{ mt: 2 }}
           onClick={() => {
-            mezzoClient.current?.send('api.response', dummyData, false);
+            const uuid =
+              mezzoClient.current?.captureApiRequest({
+                url: 'https://someUrl.com/a/b/c/',
+                method: 'POST',
+                data: null,
+                headers: null,
+                params: null,
+              }) ?? '';
+            setLastUuid(uuid);
+            log.debug('RecordScreen] sent guid', uuid);
           }}
         >
-          {width >= 960 ? 'Load dummy data' : <ClearAll />}
+          {width >= 960 ? 'Load dummy request' : <ClearAll />}
+        </Button>
+        <Button
+          variant="outlined"
+          sx={{ mt: 2 }}
+          onClick={() => {
+            mezzoClient.current?.captureApiResponse(
+              dummyData.request,
+              dummyData.response,
+              dummyData.duration,
+              lastUuid
+            );
+            setLastUuid('');
+          }}
+        >
+          {width >= 960 ? 'Load dummy response' : <ClearAll />}
         </Button>
         <Button
           variant="outlined"

--- a/apps/admin-web/src/app/hooks/useRecordingClient.ts
+++ b/apps/admin-web/src/app/hooks/useRecordingClient.ts
@@ -70,7 +70,7 @@ export default function useRecordingClient() {
   useEffect(() => {
     const onCommand = (data: any) => {
       log.debug('[useRecordingClient] received', data);
-      if (data.type === 'api.response') {
+      if (data.type === 'api.request' || data.type === 'api.response') {
         const message: RecordedItem = data;
         dispatch({ type: 'add', payload: message });
       }

--- a/libs/core-client/src/lib/plugins/__tests__/webSocketClient.spec.ts
+++ b/libs/core-client/src/lib/plugins/__tests__/webSocketClient.spec.ts
@@ -191,12 +191,18 @@ describe('webSocketClient', () => {
         createSocket,
         port,
       });
-      client.captureApiRequest('someMethod', 'someUrl');
+      client.captureApiRequest({
+        method: 'someMethod',
+        url: 'someUrl',
+        data: null,
+        headers: null,
+        params: null,
+      });
       await waitForMessageLength(2);
       expect(messages[1].type).toBe('api.request');
-      expect(messages[1].payload.method).toBe('someMethod');
-      expect(messages[1].payload.url).toBe('someUrl');
-      expect(messages[1].payload.guid).toBeDefined();
+      expect(messages[1].payload.request.method).toBe('someMethod');
+      expect(messages[1].payload.request.url).toBe('someUrl');
+      expect(messages[1].payload.uuid).toBeDefined();
       expect(messages[1].important).toBe(false);
       expect(messages[1].deltaTime).toBeDefined();
       expect(messages[1].date).toBeDefined();

--- a/libs/core-client/src/lib/plugins/webSocketClient.ts
+++ b/libs/core-client/src/lib/plugins/webSocketClient.ts
@@ -234,31 +234,38 @@ export function webSocketClient(options: IWebSocketClientOptions) {
     }
   };
 
-  const captureApiRequest = (method: string, url: string) => {
-    const guid = generateGuid();
-    console.debug('Firing API request');
-    send(MEZZO_WS_API_REQUEST, { method, url, guid });
-    return guid;
+  const captureApiRequest = (request: MezzoRecordedRequest): string => {
+    const uuid = generateGuid();
+    log.debug('[webSocketClient.captureApiRequest] generated guid', uuid);
+    send(MEZZO_WS_API_REQUEST, {
+      request,
+      uuid,
+    });
+    return uuid;
   };
 
   const captureApiResponse = (
     request: MezzoRecordedRequest,
     response: MezzoRecordedResponse,
     duration: number,
-    guid = generateGuid()
+    uuid = generateGuid()
   ) => {
     const ok = response?.status >= 200 && response?.status <= 299;
     const important = !ok;
 
-    log.debug('[mezzo-core-cleint.captureApiResponse]', {
+    log.debug('[mezzo-core-client.captureApiResponse]', {
       type: MEZZO_WS_API_RESPONSE,
       request,
       response,
       duration,
       important,
-      guid,
+      uuid,
     });
-    send(MEZZO_WS_API_RESPONSE, { request, response, duration }, important);
+    send(
+      MEZZO_WS_API_RESPONSE,
+      { request, response, duration, uuid: uuid },
+      important
+    );
   };
 
   // Don't return strings, numbers as those won't change/update

--- a/libs/interfaces/src/lib/apiInterfaces.ts
+++ b/libs/interfaces/src/lib/apiInterfaces.ts
@@ -39,6 +39,7 @@ export interface SocketRequestResponseMessage {
         request: MezzoRecordedRequest;
         response: MezzoRecordedResponse;
         duration: number;
+        uuid: string;
       }
     | Record<string, never>;
   important: boolean;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3091143/171549109-61a99585-ec85-4630-8fbf-1aa215866173.png)
![image](https://user-images.githubusercontent.com/3091143/171549134-0e065b99-7d3b-4932-9066-6e4e1f7435dd.png)

screenshots use mock request and response data with same GUID so URL differs (not realistic scenario) but concept is request will show, then when fulfilled with response it will update based on matching GUID.

Specifically when we receive a recording item we "add it", if GUID is new it's added.  Then when response is received, since GUID already exists, it updates the record in the reducer.  

If for some reason response comes through with no existing entry in reducer that is fine it's added, idea is if no GUID match we add, if match we update the record.