### PR TITLE
fix(sessionstate): add condition to initialize session object if not present in state

### DIFF
--- a/libs/core-server/src/lib/models/sessionState.ts
+++ b/libs/core-server/src/lib/models/sessionState.ts
@@ -34,6 +34,10 @@ export class SessionState {
     payload: SetRouteVariant
   ) {
     payload.forEach((item) => {
+      if (!this.state[sessionId]) {
+        this.state[sessionId] = {};
+      }
+
       this.state[sessionId][item.routeID] = item.variantID;
     });
   }


### PR DESCRIPTION
 * When attempting to update variants with endpoint `/sessionVariantState/set/:sessionId`, app was crashing if session didn't already have an object in session state.
* Fix: If session doesn't exist in session state, then create one and _then_ add variant data to it.

Anyone have opinion on my change? Part of me wants to keep the `updateSessionVariantStateByKey` simple and assume that a session (and `sessionID`) already exists. However, that assumes that the client has previously called `sessionVariantState/set/:sessionId` to create a session in state, which might not be true. 

My change ensures there's always a session state object to write the variant data to.

Image of crash:
![mezzo-crash](https://github.com/user-attachments/assets/3358a418-105f-4fe1-86dc-34fc69f0ac33)
